### PR TITLE
fix: pool data API format parsing + wallet direct nav redirect

### DIFF
--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -20,7 +20,7 @@ import SendModal from './components/SendModal';
 type TabView = 'balances' | 'utxos' | 'transactions' | 'settings';
 
 export default function WalletDashboardPage() {
-  const { connected, isConnected, address, paymentAddress, network } = useWallet() as any;
+  const { connected, isConnected, isInitializing, address, paymentAddress, network } = useWallet() as any;
   const { t } = useTranslation();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -58,7 +58,14 @@ export default function WalletDashboardPage() {
 
   const walletConnected = typeof connected === 'boolean' ? connected : isConnected;
 
-  // Redirect if not connected
+  // Wait for wallet context to finish hydrating before deciding to redirect.
+  // On direct page load, isConnected starts false until localStorage/sessionStorage
+  // state is restored. Without this guard, the page redirects to "/" immediately.
+  if (isInitializing) {
+    return null;
+  }
+
+  // Redirect if not connected (after hydration is complete)
   if (!walletConnected) {
     router.push('/');
     return null;


### PR DESCRIPTION
## Summary
- **Pool hooks broken by data API format mismatch**: `useAlkanesTokenPairs` and `useDynamicPools` failed to parse responses from `dataApiGetAllPoolsDetails` and `dataApiGetAllTokenPairs`. The `normalizePoolArray` function didn't handle `{data: {pools: [...]}}`, and `toPoolRow` only recognized RPC field names (`pool_block_id`) but not data API formats (`poolId.block`, `token0.alkaneId.block`). All pool IDs defaulted to 0, causing swap quotes to fail (no pools found).
- **Falsy zero bug**: Token ID checks used `&&` which treated `0` as falsy, breaking pools with DIESEL (`2:0`) where `tx=0` is valid. Fixed to use `!= null`.
- **Wallet redirect on direct navigation**: Navigating directly to `/wallet?tab=balances` redirected to `/` because `isConnected` was `false` during initial render before WalletContext hydration. Now waits for `isInitializing` to become `false` before evaluating the redirect.

## Test plan
- [ ] Verify swap page loads pools and shows quotes (buy/sell)
- [ ] Verify `/wallet?tab=balances` loads correctly on direct navigation when wallet is connected
- [ ] Verify `/wallet` still redirects to `/` when no wallet is connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)