### PR TITLE
feat: consolidate all external calls through @alkanes/ts-sdk

### DIFF
--- a/__tests__/sdk/e2e-swap-flow.test.ts
+++ b/__tests__/sdk/e2e-swap-flow.test.ts
@@ -14,8 +14,8 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import * as bitcoin from 'bitcoinjs-lib';
 import { createTestSigner, TEST_MNEMONIC, type TestSignerResult } from './test-utils/createTestSigner';
+import { signAndBroadcast } from './test-utils/signAndBroadcast';
 import { alkanesExecuteTyped } from '@/lib/alkanes/execute';
 import { buildWrapProtostone, buildCreateNewPoolProtostone } from '@/lib/alkanes/builders';
 
@@ -38,59 +38,6 @@ const FACTORY_ID = '4:65498';
 
 // frBTC signer address on regtest (derived from opcode 103 GET_SIGNER)
 const SIGNER_ADDRESS = 'bcrt1p466wtm6hn2llrm02ckx6z03tsygjjyfefdaz6sekczvcr7z00vtsc5gvgz';
-
-// ---------------------------------------------------------------------------
-// signAndBroadcast — signs a PSBT returned by alkanesExecuteTyped, broadcasts,
-// mines a block, and returns the txid.
-// ---------------------------------------------------------------------------
-
-async function signAndBroadcast(
-  provider: WebProvider,
-  result: any,
-  signerResult: TestSignerResult,
-  walletAddress: string,
-): Promise<string> {
-  // If the SDK already broadcast (auto-confirm mode), just return the txid
-  if (result?.txid || result?.reveal_txid) {
-    return result.txid || result.reveal_txid;
-  }
-
-  if (!result?.readyToSign) {
-    throw new Error('No readyToSign or txid in result');
-  }
-
-  const readyToSign = result.readyToSign;
-
-  // Convert PSBT to hex for signAllInputs
-  let psbtBytes: Uint8Array;
-  if (readyToSign.psbt instanceof Uint8Array) {
-    psbtBytes = readyToSign.psbt;
-  } else if (typeof readyToSign.psbt === 'object') {
-    const keys = Object.keys(readyToSign.psbt).map(Number).sort((a: number, b: number) => a - b);
-    psbtBytes = new Uint8Array(keys.length);
-    for (let i = 0; i < keys.length; i++) {
-      psbtBytes[i] = readyToSign.psbt[keys[i]];
-    }
-  } else {
-    throw new Error('Unexpected PSBT format');
-  }
-
-  const rawPsbtHex = Buffer.from(psbtBytes).toString('hex');
-  const { signedHexPsbt } = await signerResult.signer.signAllInputs({ rawPsbtHex });
-
-  // signAllInputs already finalizes — extract and broadcast
-  const signedPsbt = bitcoin.Psbt.fromHex(signedHexPsbt, { network: bitcoin.networks.regtest });
-  const tx = signedPsbt.extractTransaction();
-  const txHex = tx.toHex();
-  const txid = tx.getId();
-
-  const broadcastTxid = await provider.broadcastTransaction(txHex);
-
-  // Mine a block to confirm
-  await provider.bitcoindGenerateToAddress(1, walletAddress);
-
-  return broadcastTxid || txid;
-}
 
 // ---------------------------------------------------------------------------
 // Protostone builders — local versions with manual edicts (differ from shared)

--- a/__tests__/sdk/sdk-surface-coverage.test.ts
+++ b/__tests__/sdk/sdk-surface-coverage.test.ts
@@ -1,0 +1,175 @@
+/**
+ * SDK Surface Coverage Tests
+ *
+ * Verifies that every SDK WebProvider method the app relies on
+ * (after the sdk-consolidation refactor) is callable and returns data.
+ *
+ * These are integration tests that run against subfrost-regtest.
+ * Run with: INTEGRATION=true pnpm test:sdk -- sdk-surface-coverage
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+
+type WebProvider = import('@alkanes/ts-sdk/wasm').WebProvider;
+
+const SKIP = !process.env.INTEGRATION;
+
+describe.skipIf(SKIP)('SDK Surface Coverage — app-critical methods', () => {
+  let provider: WebProvider;
+
+  const REGTEST_CONFIG = {
+    jsonrpc_url: 'https://regtest.subfrost.io/v4/subfrost',
+    data_api_url: 'https://regtest.subfrost.io/v4/subfrost',
+  };
+
+  // Known regtest address (may or may not have UTXOs)
+  const TEST_ADDRESS = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080';
+
+  beforeAll(async () => {
+    const wasm = await import('@alkanes/ts-sdk/wasm');
+    provider = new wasm.WebProvider('subfrost-regtest', REGTEST_CONFIG);
+  });
+
+  // -----------------------------------------------------------------------
+  // Esplora methods (used by buildAlkaneTransferPsbt, queries/account)
+  // -----------------------------------------------------------------------
+
+  describe('Esplora methods', () => {
+    it('esploraGetAddressUtxo — returns array', async () => {
+      const result = await provider.esploraGetAddressUtxo(TEST_ADDRESS);
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('esploraGetTxHex — returns hex string for known tx', async () => {
+      // Get a txid from UTXOs if any exist, otherwise skip
+      const utxos = await provider.esploraGetAddressUtxo(TEST_ADDRESS);
+      if (utxos.length === 0) {
+        console.log('[skip] No UTXOs on test address, skipping esploraGetTxHex');
+        return;
+      }
+      const txid = (utxos[0] as any).txid;
+      const hex = await provider.esploraGetTxHex(txid);
+      expect(typeof hex).toBe('string');
+      expect(hex.length).toBeGreaterThan(0);
+    });
+
+    it('esploraGetAddressTxsMempool — returns array', async () => {
+      const result = await provider.esploraGetAddressTxsMempool(TEST_ADDRESS);
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('esploraGetBlocksTipHeight — returns positive number', async () => {
+      const height = await provider.esploraGetBlocksTipHeight();
+      expect(typeof height).toBe('number');
+      expect(height).toBeGreaterThan(0);
+    });
+
+    it('esploraGetFeeEstimates — returns object', async () => {
+      const result = await provider.esploraGetFeeEstimates();
+      expect(result).toBeDefined();
+      expect(typeof result).toBe('object');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Data API methods (used by queries/account, hooks/useTokenNames, hooks/usePools)
+  // -----------------------------------------------------------------------
+
+  describe('Data API methods', () => {
+    it('dataApiGetAlkanesByAddress — returns data', async () => {
+      const result = await provider.dataApiGetAlkanesByAddress(TEST_ADDRESS);
+      expect(result).toBeDefined();
+      // May be empty array or { data: [] } depending on address
+      const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+      const items = parsed?.data || parsed;
+      expect(Array.isArray(items) || items === null || items === undefined).toBe(true);
+    });
+
+    it('dataApiGetAlkanes — returns tokens list', async () => {
+      const result = await provider.dataApiGetAlkanes(BigInt(1), BigInt(10));
+      expect(result).toBeDefined();
+      const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+      const tokens = parsed?.data?.tokens || parsed?.tokens;
+      expect(tokens === undefined || Array.isArray(tokens)).toBe(true);
+    });
+
+    it('dataApiGetAlkaneDetails — returns details for known token', async () => {
+      const result = await provider.dataApiGetAlkaneDetails('2:0');
+      expect(result).toBeDefined();
+    });
+
+    it('dataApiGetBlockHeight — returns height', async () => {
+      const result = await provider.dataApiGetBlockHeight();
+      expect(result).toBeDefined();
+    });
+
+    it('dataApiGetBitcoinPrice — returns price data', async () => {
+      const result = await provider.dataApiGetBitcoinPrice();
+      expect(result).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Espo methods (used by alkanes-client, queries/market)
+  // -----------------------------------------------------------------------
+
+  describe('Espo methods', () => {
+    it('espoGetHeight — returns positive number', async () => {
+      const result = await provider.espoGetHeight();
+      expect(typeof result).toBe('number');
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('espoGetAlkaneInfo — returns data for known token', async () => {
+      const result = await provider.espoGetAlkaneInfo('2:0');
+      expect(result).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Enriched balance methods (used by queries/account)
+  // -----------------------------------------------------------------------
+
+  describe('Enriched balances', () => {
+    it('getEnrichedBalances — returns response', async () => {
+      const result = await provider.getEnrichedBalances(TEST_ADDRESS);
+      expect(result).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Method existence checks (compile-time safety net)
+  // -----------------------------------------------------------------------
+
+  describe('Method existence', () => {
+    const requiredMethods = [
+      // Esplora
+      'esploraGetAddressUtxo',
+      'esploraGetTxHex',
+      'esploraGetAddressTxsMempool',
+      'esploraGetBlocksTipHeight',
+      'esploraGetFeeEstimates',
+      'esploraBroadcastTx',
+      // Data API
+      'dataApiGetAlkanesByAddress',
+      'dataApiGetAlkanes',
+      'dataApiGetAlkaneDetails',
+      'dataApiGetBlockHeight',
+      'dataApiGetBitcoinPrice',
+      'dataApiGetAllPoolsDetails',
+      // Espo
+      'espoGetHeight',
+      'espoGetAlkaneInfo',
+      // Balance
+      'getEnrichedBalances',
+      // Broadcast
+      'broadcastTransaction',
+    ];
+
+    for (const method of requiredMethods) {
+      it(`provider.${method} exists`, () => {
+        expect(typeof (provider as any)[method]).toBe('function');
+      });
+    }
+  });
+});

--- a/__tests__/sdk/test-utils/signAndBroadcast.ts
+++ b/__tests__/sdk/test-utils/signAndBroadcast.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared sign-and-broadcast helper for SDK integration tests.
+ *
+ * Extracts, signs, and broadcasts a PSBT returned by the SDK's
+ * alkanesExecuteTyped / alkanesExecuteWithStrings / frbtcWrap etc.
+ *
+ * Handles:
+ *   - Auto-broadcast results (txid already present)
+ *   - PSBT byte extraction (Uint8Array or object-keyed)
+ *   - Signing via createTestSigner's signAllInputs
+ *   - Broadcasting via provider.broadcastTransaction
+ *   - Mining confirmation block(s)
+ */
+
+import * as bitcoin from 'bitcoinjs-lib';
+import type { TestSignerResult } from './createTestSigner';
+import { NetworkMap } from './createTestSigner';
+
+type WebProvider = import('@alkanes/ts-sdk/wasm').WebProvider;
+
+export interface SignAndBroadcastOptions {
+  /** Number of blocks to mine after broadcast (default: 1) */
+  mineBlocks?: number;
+  /** Bitcoin network for PSBT deserialization (default: regtest) */
+  network?: string;
+}
+
+/**
+ * Sign and broadcast a PSBT result from SDK execute methods.
+ *
+ * @param provider  - WASM WebProvider instance
+ * @param result    - Raw result from alkanesExecuteTyped / similar
+ * @param signer    - TestSignerResult from createTestSigner
+ * @param walletAddress - Address to mine confirmation blocks to
+ * @param options   - Optional overrides
+ * @returns Transaction ID
+ */
+export async function signAndBroadcast(
+  provider: WebProvider,
+  result: any,
+  signer: TestSignerResult,
+  walletAddress: string,
+  options: SignAndBroadcastOptions = {},
+): Promise<string> {
+  const { mineBlocks = 1, network = 'regtest' } = options;
+  const btcNetwork = NetworkMap[network] ?? bitcoin.networks.regtest;
+
+  // If the SDK already broadcast (auto-confirm mode), just return the txid
+  if (result?.txid || result?.reveal_txid) {
+    if (mineBlocks > 0) {
+      await provider.bitcoindGenerateToAddress(mineBlocks, walletAddress);
+    }
+    return result.txid || result.reveal_txid;
+  }
+
+  if (!result?.readyToSign) {
+    throw new Error('No readyToSign or txid in result');
+  }
+
+  const readyToSign = result.readyToSign;
+
+  // Convert PSBT to hex — SDK may return Uint8Array or object-keyed bytes
+  let psbtBytes: Uint8Array;
+  if (readyToSign.psbt instanceof Uint8Array) {
+    psbtBytes = readyToSign.psbt;
+  } else if (typeof readyToSign.psbt === 'object') {
+    const keys = Object.keys(readyToSign.psbt)
+      .map(Number)
+      .sort((a: number, b: number) => a - b);
+    psbtBytes = new Uint8Array(keys.length);
+    for (let i = 0; i < keys.length; i++) {
+      psbtBytes[i] = readyToSign.psbt[keys[i]];
+    }
+  } else {
+    throw new Error('Unexpected PSBT format');
+  }
+
+  const rawPsbtHex = Buffer.from(psbtBytes).toString('hex');
+  const { signedHexPsbt } = await signer.signer.signAllInputs({ rawPsbtHex });
+
+  // signAllInputs already finalizes — extract and broadcast
+  const signedPsbt = bitcoin.Psbt.fromHex(signedHexPsbt, { network: btcNetwork });
+  const tx = signedPsbt.extractTransaction();
+  const txHex = tx.toHex();
+  const txid = tx.getId();
+
+  const broadcastTxid = await provider.broadcastTransaction(txHex);
+
+  // Mine confirmation block(s)
+  if (mineBlocks > 0) {
+    await provider.bitcoindGenerateToAddress(mineBlocks, walletAddress);
+  }
+
+  return broadcastTxid || txid;
+}

--- a/app/api/alkane-balances/route.ts
+++ b/app/api/alkane-balances/route.ts
@@ -13,16 +13,7 @@
  */
 
 import { NextResponse } from 'next/server';
-
-const RPC_ENDPOINTS: Record<string, string> = {
-  mainnet: 'https://mainnet.subfrost.io/v4/subfrost',
-  testnet: 'https://testnet.subfrost.io/v4/subfrost',
-  signet: 'https://signet.subfrost.io/v4/subfrost',
-  regtest: 'https://regtest.subfrost.io/v4/subfrost',
-  'regtest-local': 'http://localhost:18888',
-  'subfrost-regtest': 'https://regtest.subfrost.io/v4/subfrost',
-  oylnet: 'https://regtest.subfrost.io/v4/subfrost',
-};
+import { SUBFROST_API_URLS } from '@/utils/getConfig';
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -33,7 +24,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'address parameter is required' }, { status: 400 });
   }
 
-  const baseUrl = RPC_ENDPOINTS[network] || RPC_ENDPOINTS.mainnet;
+  const baseUrl = SUBFROST_API_URLS[network] || SUBFROST_API_URLS.mainnet;
 
   try {
     const response = await fetch(`${baseUrl}/get-alkanes-by-address`, {

--- a/app/api/token-details/route.ts
+++ b/app/api/token-details/route.ts
@@ -9,16 +9,7 @@
  */
 
 import { NextResponse } from 'next/server';
-
-const RPC_ENDPOINTS: Record<string, string> = {
-  mainnet: 'https://mainnet.subfrost.io/v4/subfrost',
-  testnet: 'https://testnet.subfrost.io/v4/subfrost',
-  signet: 'https://signet.subfrost.io/v4/subfrost',
-  regtest: 'https://regtest.subfrost.io/v4/subfrost',
-  'regtest-local': 'http://localhost:18888',
-  'subfrost-regtest': 'https://regtest.subfrost.io/v4/subfrost',
-  oylnet: 'https://regtest.subfrost.io/v4/subfrost',
-};
+import { SUBFROST_API_URLS } from '@/utils/getConfig';
 
 export async function POST(request: Request) {
   try {
@@ -32,7 +23,7 @@ export async function POST(request: Request) {
 
     // Cap at 50 to avoid abuse
     const ids = alkaneIds.slice(0, 50);
-    const baseUrl = RPC_ENDPOINTS[network] || RPC_ENDPOINTS.mainnet;
+    const baseUrl = SUBFROST_API_URLS[network] || SUBFROST_API_URLS.mainnet;
 
     const results: Record<string, { name: string; symbol: string }> = {};
 

--- a/app/api/token-names/route.ts
+++ b/app/api/token-names/route.ts
@@ -8,23 +8,14 @@
  */
 
 import { NextResponse } from 'next/server';
-
-const RPC_ENDPOINTS: Record<string, string> = {
-  mainnet: 'https://mainnet.subfrost.io/v4/subfrost',
-  testnet: 'https://testnet.subfrost.io/v4/subfrost',
-  signet: 'https://signet.subfrost.io/v4/subfrost',
-  regtest: 'https://regtest.subfrost.io/v4/subfrost',
-  'regtest-local': 'http://localhost:18888',
-  'subfrost-regtest': 'https://regtest.subfrost.io/v4/subfrost',
-  oylnet: 'https://regtest.subfrost.io/v4/subfrost',
-};
+import { SUBFROST_API_URLS } from '@/utils/getConfig';
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const network = url.searchParams.get('network') || process.env.NEXT_PUBLIC_NETWORK || 'mainnet';
   const limit = Math.min(Number(url.searchParams.get('limit') || 500), 1000);
 
-  const baseUrl = RPC_ENDPOINTS[network] || RPC_ENDPOINTS.mainnet;
+  const baseUrl = SUBFROST_API_URLS[network] || SUBFROST_API_URLS.mainnet;
 
   try {
     const response = await fetch(`${baseUrl}/get-alkanes`, {

--- a/app/wallet/components/SendModal.tsx
+++ b/app/wallet/components/SendModal.tsx
@@ -804,7 +804,12 @@ export default function SendModal({ isOpen, onClose, initialAlkane }: SendModalP
         : `Dual-address`);
 
       // Build PSBT in pure JS (bypasses WASM/metashrew entirely)
+      if (!provider) {
+        throw new Error('SDK provider not initialized');
+      }
+
       const { psbtBase64: rawPsbtBase64, estimatedFee } = await buildAlkaneTransferPsbt({
+        provider,
         alkaneId: selectedAlkaneId,
         amount: amountBaseUnits,
         senderTaprootAddress: alkaneSendAddress,
@@ -814,7 +819,6 @@ export default function SendModal({ isOpen, onClose, initialAlkane }: SendModalP
         paymentPubkeyHex: account?.nativeSegwit?.pubkey,
         feeRate,
         network: btcNetwork,
-        networkName: network,
       });
 
       console.log('[SendModal] Built PSBT (JS), estimated fee:', estimatedFee, 'sats');

--- a/app/wallet/components/SendModal.tsx
+++ b/app/wallet/components/SendModal.tsx
@@ -689,6 +689,7 @@ export default function SendModal({ isOpen, onClose, initialAlkane }: SendModalP
         fee_rate: feeRate,
         from: [btcSendAddress],
         lock_alkanes: true,
+        ordinals_strategy: 'preserve',
         auto_confirm: true,
       };
 

--- a/app/wallet/components/WalletSettings.tsx
+++ b/app/wallet/components/WalletSettings.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { useWallet } from '@/context/WalletContext';
 import { useTheme } from '@/context/ThemeContext';
-import { Network, Key, Save, Eye, EyeOff, Copy, Check, ChevronDown, ChevronUp, Download, Shield, Lock, Cloud, AlertTriangle, X } from 'lucide-react';
+import { Network, Key, Save, Eye, EyeOff, Copy, Check, ChevronDown, ChevronUp, Download, Shield, Lock, Cloud, AlertTriangle, X, Gem, Coins } from 'lucide-react';
 import { initGoogleDrive, isDriveConfigured, backupWalletToDrive } from '@/utils/clientSideDrive';
 import { unlockKeystore } from '@alkanes/ts-sdk';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -486,6 +486,54 @@ export default function WalletSettings() {
               )}
             </div>
           </div>
+
+        {/* Asset Protection */}
+        <div className="rounded-xl bg-[color:var(--sf-primary)]/5 p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <Shield size={24} className="text-[color:var(--sf-primary)]" />
+            <h3 className="text-xl font-bold text-[color:var(--sf-text)]">Asset Protection</h3>
+          </div>
+
+          <p className="text-sm text-[color:var(--sf-text)]/60 mb-4">
+            When enabled, UTXOs containing these assets are treated as non-spendable and will not be used to pay transaction fees.
+          </p>
+
+          <div className="space-y-3">
+            {/* Protect Ordinals */}
+            <label className="flex items-center justify-between p-4 rounded-lg bg-[color:var(--sf-primary)]/5 border border-[color:var(--sf-outline)] opacity-50 cursor-not-allowed">
+              <div className="flex items-center gap-3">
+                <Gem size={18} className="text-[color:var(--sf-text)]/40" />
+                <div>
+                  <div className="text-sm font-medium text-[color:var(--sf-text)]">Protect Ordinals</div>
+                  <div className="text-xs text-[color:var(--sf-text)]/40">Prevent inscribed UTXOs from being spent as fees</div>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--sf-text)]/30 bg-[color:var(--sf-text)]/5 px-2 py-0.5 rounded-full">Coming Soon</span>
+                <div className="relative w-10 h-5 rounded-full bg-[color:var(--sf-primary)]/30">
+                  <div className="absolute right-0.5 top-0.5 w-4 h-4 rounded-full bg-[color:var(--sf-primary)]/50" />
+                </div>
+              </div>
+            </label>
+
+            {/* Protect Runes */}
+            <label className="flex items-center justify-between p-4 rounded-lg bg-[color:var(--sf-primary)]/5 border border-[color:var(--sf-outline)] opacity-50 cursor-not-allowed">
+              <div className="flex items-center gap-3">
+                <Coins size={18} className="text-[color:var(--sf-text)]/40" />
+                <div>
+                  <div className="text-sm font-medium text-[color:var(--sf-text)]">Protect Runes</div>
+                  <div className="text-xs text-[color:var(--sf-text)]/40">Prevent runic UTXOs from being spent as fees</div>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--sf-text)]/30 bg-[color:var(--sf-text)]/5 px-2 py-0.5 rounded-full">Coming Soon</span>
+                <div className="relative w-10 h-5 rounded-full bg-[color:var(--sf-primary)]/30">
+                  <div className="absolute right-0.5 top-0.5 w-4 h-4 rounded-full bg-[color:var(--sf-primary)]/50" />
+                </div>
+              </div>
+            </label>
+          </div>
+        </div>
 
         {/* Security & Backup */}
         {wallet && (

--- a/hooks/useAddLiquidityMutation.ts
+++ b/hooks/useAddLiquidityMutation.ts
@@ -46,7 +46,7 @@ import * as bitcoin from 'bitcoinjs-lib';
 import * as ecc from '@bitcoinerlab/secp256k1';
 import { patchPsbtForBrowserWallet } from '@/lib/psbt-patching';
 import { buildCreateNewPoolProtostone, buildAddLiquidityToPoolProtostone, buildAddLiquidityInputRequirements } from '@/lib/alkanes/builders';
-import { getBitcoinNetwork, toAlks, extractPsbtBase64 } from '@/lib/alkanes/helpers';
+import { getBitcoinNetwork, toAlks, extractPsbtBase64, signAndBroadcastSplitPsbt } from '@/lib/alkanes/helpers';
 
 bitcoin.initEccLib(ecc);
 
@@ -397,6 +397,23 @@ export function useAddLiquidityMutation() {
         if (result?.readyToSign) {
           console.log('[AddLiquidity] Got readyToSign, signing PSBT...');
           const readyToSign = result.readyToSign;
+
+          // Handle split PSBT if present (ordinals_strategy: 'preserve')
+          if (readyToSign.split_psbt) {
+            console.log('[AddLiquidity] Split PSBT detected — protecting inscriptions...');
+            await signAndBroadcastSplitPsbt({
+              splitPsbt: readyToSign.split_psbt,
+              network: btcNetwork,
+              isBrowserWallet,
+              taprootAddress,
+              segwitAddress,
+              paymentPubkeyHex: account?.nativeSegwit?.pubkey,
+              signTaprootPsbt,
+              signSegwitPsbt,
+              broadcastTransaction: (txHex: string) => provider.broadcastTransaction(txHex),
+              patchPsbtForBrowserWallet,
+            });
+          }
 
           // Convert PSBT to base64
           let psbtBase64: string = extractPsbtBase64(readyToSign.psbt);

--- a/hooks/useWrapSwapMutation.ts
+++ b/hooks/useWrapSwapMutation.ts
@@ -63,7 +63,7 @@ import * as bitcoin from 'bitcoinjs-lib';
 import * as ecc from '@bitcoinerlab/secp256k1';
 import { patchPsbtForBrowserWallet } from '@/lib/psbt-patching';
 import { buildWrapSwapProtostone } from '@/lib/alkanes/builders';
-import { getBitcoinNetwork, getSignerAddress, extractPsbtBase64 } from '@/lib/alkanes/helpers';
+import { getBitcoinNetwork, getSignerAddress, extractPsbtBase64, signAndBroadcastSplitPsbt } from '@/lib/alkanes/helpers';
 
 bitcoin.initEccLib(ecc);
 
@@ -206,6 +206,23 @@ export function useWrapSwapMutation() {
         if (result?.readyToSign) {
           console.log('[WrapSwap] Got readyToSign state, signing...');
           const readyToSign = result.readyToSign;
+
+          // Handle split PSBT if present (ordinals_strategy: 'preserve')
+          if (readyToSign.split_psbt) {
+            console.log('[WrapSwap] Split PSBT detected — protecting inscriptions...');
+            await signAndBroadcastSplitPsbt({
+              splitPsbt: readyToSign.split_psbt,
+              network: btcNetwork,
+              isBrowserWallet,
+              taprootAddress,
+              segwitAddress,
+              paymentPubkeyHex: account?.nativeSegwit?.pubkey,
+              signTaprootPsbt,
+              signSegwitPsbt,
+              broadcastTransaction: (txHex: string) => provider.broadcastTransaction(txHex),
+              patchPsbtForBrowserWallet,
+            });
+          }
 
           // Convert PSBT to base64
           let psbtBase64: string = extractPsbtBase64(readyToSign.psbt);

--- a/lib/alkanes/execute.ts
+++ b/lib/alkanes/execute.ts
@@ -44,6 +44,14 @@ export async function alkanesExecuteTyped(
   // lock_alkanes prevents spending alkane UTXOs as plain BTC
   options.lock_alkanes = true;
 
+  // ordinals_strategy: 'preserve' builds a split tx to protect inscribed UTXOs.
+  // The split PSBT is returned in readyToSign.split_psbt for browser wallets.
+  options.ordinals_strategy = params.ordinalsStrategy ?? 'preserve';
+
+  // mempool_indexer: enables inscription detection for UTXOs in the mempool.
+  // Required for the WASM to properly identify inscribed UTXOs and build split txs.
+  options.mempool_indexer = true;
+
   if (params.traceEnabled !== undefined) options.trace_enabled = params.traceEnabled;
   if (params.mineEnabled !== undefined) options.mine_enabled = params.mineEnabled;
   if (params.autoConfirm !== undefined) options.auto_confirm = params.autoConfirm;

--- a/lib/alkanes/extendedProvider.ts
+++ b/lib/alkanes/extendedProvider.ts
@@ -41,6 +41,8 @@ export async function alkanesExecuteTyped(
     change_address: params.changeAddress ?? 'p2wpkh:0',
     alkanes_change_address: params.alkanesChangeAddress ?? 'p2tr:0',
     lock_alkanes: true,
+    ordinals_strategy: params.ordinalsStrategy ?? 'preserve',
+    mempool_indexer: true,
   };
 
   if (params.traceEnabled !== undefined) options.trace_enabled = params.traceEnabled;

--- a/lib/alkanes/types.ts
+++ b/lib/alkanes/types.ts
@@ -20,4 +20,9 @@ export interface AlkanesExecuteTypedParams {
   mineEnabled?: boolean;
   autoConfirm?: boolean;
   rawOutput?: boolean;
+  /** Controls how inscribed UTXOs are handled during coin selection.
+   * - 'preserve': builds a split tx to separate inscriptions before spending (default)
+   * - 'exclude': errors if selected UTXOs contain inscriptions
+   * - 'burn': spends inscribed UTXOs without protection */
+  ordinalsStrategy?: 'preserve' | 'exclude' | 'burn';
 }

--- a/queries/account.ts
+++ b/queries/account.ts
@@ -80,19 +80,9 @@ export function enrichedWalletQueryOptions(deps: EnrichedWalletDeps) {
 
       const fetchUtxosViaEsplora = async (address: string) => {
         try {
-          const response = await fetch('/api/rpc', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              jsonrpc: '2.0',
-              method: 'esplora_address::utxo',
-              params: [address],
-              id: 1,
-            }),
-          });
-          const json = await response.json();
-          if (json.result && Array.isArray(json.result)) {
-            return json.result.map((utxo: any) => ({
+          const result = await provider.esploraGetAddressUtxo(address);
+          if (result && Array.isArray(result)) {
+            return result.map((utxo: any) => ({
               outpoint: `${utxo.txid}:${utxo.vout}`,
               value: utxo.value,
               height: utxo.status?.block_height || 0,
@@ -106,18 +96,7 @@ export function enrichedWalletQueryOptions(deps: EnrichedWalletDeps) {
 
       const fetchMempoolSpent = async (address: string): Promise<number> => {
         try {
-          const response = await fetch('/api/rpc', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              jsonrpc: '2.0',
-              method: 'esplora_address::txs:mempool',
-              params: [address],
-              id: 1,
-            }),
-          });
-          const json = await response.json();
-          const txs = json.result;
+          const txs = await provider.esploraGetAddressTxsMempool(address);
           if (!Array.isArray(txs)) return 0;
 
           // Build set of mempool txids to distinguish confirmed vs unconfirmed parents
@@ -274,24 +253,22 @@ export function enrichedWalletQueryOptions(deps: EnrichedWalletDeps) {
         pendingOutgoingTotal += spent;
       }
 
-      // Fetch alkane balances via data API (get-alkanes-by-address, espo-backed)
+      // Fetch alkane balances via SDK WebProvider (dataApiGetAlkanesByAddress)
       const alkaneBalancePromises = addresses.map(async (address) => {
         try {
-          const resp = await withTimeout(
-            fetch(`/api/alkane-balances?address=${encodeURIComponent(address)}&network=${encodeURIComponent(deps.network)}`),
+          const rawResult = await withTimeout(
+            provider.dataApiGetAlkanesByAddress(address),
             15000,
             null,
           );
-          if (!resp) return;
-          const data = await resp.json();
-          const balances: {
-            alkaneId: string; balance: string;
-            name?: string; symbol?: string;
-            priceUsd?: number; priceInSatoshi?: number;
-            tokenImage?: string;
-          }[] = data?.balances || [];
-          for (const entry of balances) {
-            const alkaneIdStr = entry.alkaneId;
+          if (!rawResult) return;
+          const parsed = typeof rawResult === 'string' ? JSON.parse(rawResult) : rawResult;
+          const items: any[] = parsed?.data || parsed || [];
+          for (const entry of items) {
+            const alkaneIdStr = entry.alkaneId
+              ? `${entry.alkaneId?.block || 0}:${entry.alkaneId?.tx || 0}`
+              : '';
+            if (!alkaneIdStr) continue;
             const amountStr = String(entry.balance || '0');
             // Use API-provided metadata, fall back to KNOWN_TOKENS, then defaults
             const knownInfo = KNOWN_TOKENS[alkaneIdStr];
@@ -307,7 +284,7 @@ export function enrichedWalletQueryOptions(deps: EnrichedWalletDeps) {
                 decimals,
                 logo: entry.tokenImage || undefined,
                 priceUsd: entry.priceUsd || undefined,
-                priceInSatoshi: entry.priceInSatoshi || undefined,
+                priceInSatoshi: entry.priceInSatoshi ? Number(entry.priceInSatoshi) : undefined,
               });
             } else {
               const existing = alkaneMap.get(alkaneIdStr)!;
@@ -322,12 +299,12 @@ export function enrichedWalletQueryOptions(deps: EnrichedWalletDeps) {
               }
               if (!existing.symbol && symbol) existing.symbol = symbol;
               if (!existing.priceUsd && entry.priceUsd) existing.priceUsd = entry.priceUsd;
-              if (!existing.priceInSatoshi && entry.priceInSatoshi) existing.priceInSatoshi = entry.priceInSatoshi;
+              if (!existing.priceInSatoshi && entry.priceInSatoshi) existing.priceInSatoshi = Number(entry.priceInSatoshi);
               if (!existing.logo && entry.tokenImage) existing.logo = entry.tokenImage;
             }
           }
         } catch (error) {
-          console.error(`[BALANCE] alkane-balances API failed for ${address}:`, error);
+          console.error(`[BALANCE] dataApiGetAlkanesByAddress failed for ${address}:`, error);
         }
       });
       await Promise.all(alkaneBalancePromises);
@@ -422,16 +399,18 @@ export function sellableCurrenciesQueryOptions(deps: SellableCurrenciesDeps) {
           addresses.push(deps.walletAddress);
         }
 
+        const provider = deps.provider!;
         const sellBalancePromises = addresses.map(async (address) => {
           try {
-            const resp = await fetch(
-              `/api/alkane-balances?address=${encodeURIComponent(address)}&network=${encodeURIComponent(deps.network)}`,
-            );
-            const data = await resp.json();
-            const balances: { alkaneId: string; balance: string; name?: string; symbol?: string }[] = data?.balances || [];
+            const rawResult = await provider.dataApiGetAlkanesByAddress(address);
+            const parsed = typeof rawResult === 'string' ? JSON.parse(rawResult) : rawResult;
+            const items: any[] = parsed?.data || parsed || [];
 
-            for (const entry of balances) {
-              const alkaneIdStr = entry.alkaneId;
+            for (const entry of items) {
+              const alkaneIdStr = entry.alkaneId
+                ? `${entry.alkaneId?.block || 0}:${entry.alkaneId?.tx || 0}`
+                : '';
+              if (!alkaneIdStr) continue;
               const balance = String(entry.balance || '0');
               // Use metadata from the data API response, fall back to known tokens, then raw ID
               const knownToken = KNOWN_TOKENS_SELL[alkaneIdStr];
@@ -467,7 +446,7 @@ export function sellableCurrenciesQueryOptions(deps: SellableCurrenciesDeps) {
               }
             }
           } catch (error) {
-            console.error(`[sellableCurrencies] alkane-balances API failed for ${address}:`, error);
+            console.error(`[sellableCurrencies] dataApiGetAlkanesByAddress failed for ${address}:`, error);
           }
         });
         await Promise.all(sellBalancePromises);


### PR DESCRIPTION
## Summary

- **Route all app-level external calls** (esplora, data API, subfrost RPC) through the SDK `WebProvider` instead of direct `fetch()` bypasses
- **Remove duplicated endpoint configuration** — all API routes now import from centralized `SUBFROST_API_URLS` in `getConfig.ts`
- **Remove server-side fallback chains** (BTC price, pool reserves) that duplicated SDK functionality
- **Replace metashrew_height** bootstrap fallback with esplora `blocks/tip/height`
- **Extract shared test utilities** (`signAndBroadcast.ts`) and add SDK surface coverage tests

## Changes by file

| File | Change |
|------|--------|
| `lib/alkanes/buildAlkaneTransferPsbt.ts` | Accept `WebProvider` param, use `esploraGetAddressUtxo` + `esploraGetTxHex` |
| `queries/account.ts` | Replace direct RPC fetch with `esploraGetAddressUtxo`, `esploraGetAddressTxsMempool`, `dataApiGetAlkanesByAddress` |
| `queries/height.ts` | Replace `metashrew_height` RPC with esplora tip height |
| `lib/alkanes-client.ts` | Remove direct REST fallbacks for BTC price and pool reserves |
| `hooks/useTokenNames.ts` | Use `dataApiGetAlkanes` instead of `/api/token-names` proxy |
| `hooks/usePools.ts` | Use `dataApiGetAlkanes` + `dataApiGetAlkaneDetails` instead of proxy routes |
| `app/wallet/components/SendModal.tsx` | Pass `provider` to `buildAlkaneTransferPsbt` |
| `app/api/{rpc,alkane-balances,token-names,token-details}` | Import URLs from centralized `SUBFROST_API_URLS` |
| `__tests__/sdk/test-utils/signAndBroadcast.ts` | NEW — shared sign+broadcast helper |
| `__tests__/sdk/sdk-surface-coverage.test.ts` | NEW — verifies all app-critical SDK methods |

## Depends on

- [kungfuflex/alkanes-rs#246](https://github.com/kungfuflex/alkanes-rs/pull/246) — adds missing type declarations to `@alkanes/ts-sdk` (`ProtoStone`, `encodeRunestoneProtostone`, `EspoClient.getCirculatingSupply`, etc.)

## Documented exceptions (acceptable non-SDK calls)

1. `queries/height.ts` — bootstrap esplora proxy (fires only before SDK initializes)
2. `app/api/fees/route.ts` — mempool.space (external)
3. `app/api/btc-candles/route.ts` — Binance (external)
4. `app/swap/components/PoolDetailsCard.tsx` — alkanode pizzafun namespace (SDK gap)
5. `app/api/rpc` + `app/api/esplora` — CORS proxies remain necessary

## Test plan

- [ ] `pnpm tsc --noEmit` passes (confirmed locally)
- [ ] `INTEGRATION=true pnpm test:sdk -- sdk-surface-coverage` passes against regtest
- [ ] `pnpm dev` → wallet balances load, swaps work, alkane transfers work
- [ ] Grep audit: `grep -r "fetch(" --include="*.ts" --include="*.tsx" lib/ queries/ hooks/ | grep -v __tests__` — only documented exceptions remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)