### PR TITLE
fix(devnet): reliable devnet detection + UI fixes for in-browser devnet

### DIFF
--- a/app/swap/SwapShell.tsx
+++ b/app/swap/SwapShell.tsx
@@ -1684,9 +1684,10 @@ export default function SwapShell() {
       if (result?.success && result.transactionId) {
         console.log('[handleRemoveLiquidity] Success! txid:', result.transactionId);
         showNotification(result.transactionId, 'removeLiquidity');
-        // Clear state after success
+        // Clear state and close modal after success
         setRemoveAmount('');
         setSelectedLPPosition(null);
+        setIsLiquidityModalOpen(false);
       }
     } catch (e: any) {
       console.error('[handleRemoveLiquidity] Error:', e);
@@ -2290,6 +2291,11 @@ export default function SwapShell() {
       <BottomPanels
         baseToken={fromToken?.symbol || 'DIESEL'}
         quoteToken={toToken?.symbol || 'frBTC'}
+        onRemovePosition={(pos) => {
+          setSelectedLPPosition(pos);
+          setLiquidityMode('remove');
+          setIsLiquidityModalOpen(true);
+        }}
       />
 
       {/* Liquidity Modal */}

--- a/app/swap/components/BottomPanels.tsx
+++ b/app/swap/components/BottomPanels.tsx
@@ -38,6 +38,7 @@ type PanelTab = 'orders' | 'positions' | 'trades' | 'activity';
 interface Props {
   baseToken: string;
   quoteToken: string;
+  onRemovePosition?: (position: any) => void;
 }
 
 function EmptyState({ icon: Icon, message }: { icon: any; message: string }) {
@@ -49,7 +50,7 @@ function EmptyState({ icon: Icon, message }: { icon: any; message: string }) {
   );
 }
 
-export default function BottomPanels({ baseToken, quoteToken }: Props) {
+export default function BottomPanels({ baseToken, quoteToken, onRemovePosition }: Props) {
   const [activeTab, setActiveTab] = useState<PanelTab>('trades');
   const { isConnected, network } = useWallet() as any;
   const { positions: allPositions, isLoading: isLoadingPositions } = useLPPositions();
@@ -199,13 +200,14 @@ export default function BottomPanels({ baseToken, quoteToken }: Props) {
             ) : (
               <div>
                 {/* Header */}
-                <div className="sf-table-header grid grid-cols-[1fr_auto_auto] gap-4 px-3 py-2">
+                <div className="sf-table-header grid grid-cols-[1fr_auto_auto_auto] gap-4 px-3 py-2">
                   <span>Pool</span>
                   <span className="text-right">Amount</span>
                   <span className="text-right w-[72px]">ID</span>
+                  <span className="w-[60px]" />
                 </div>
                 {lpPositions.map((pos) => (
-                  <div key={pos.id} className="sf-row grid grid-cols-[1fr_auto_auto] gap-4 px-3 py-2.5 items-center">
+                  <div key={pos.id} className="sf-row grid grid-cols-[1fr_auto_auto_auto] gap-4 px-3 py-2.5 items-center">
                     <div className="flex items-center gap-2 min-w-0">
                       <div className="flex -space-x-2 shrink-0">
                         <div className="relative z-10">
@@ -225,6 +227,12 @@ export default function BottomPanels({ baseToken, quoteToken }: Props) {
                     <span className="text-[10px] text-right tabular-nums text-[color:var(--sf-text)]/40 w-[72px] truncate">
                       {pos.id}
                     </span>
+                    <button
+                      onClick={() => onRemovePosition?.(pos)}
+                      className="sf-btn-ghost text-[10px] px-2 py-1 w-[60px] text-red-400 hover:text-red-300 hover:bg-red-500/10 rounded-lg"
+                    >
+                      Remove
+                    </button>
                   </div>
                 ))}
               </div>

--- a/app/swap/components/MarketsGrid.tsx
+++ b/app/swap/components/MarketsGrid.tsx
@@ -394,10 +394,12 @@ function formatCurrency(v?: number, currency: CurrencyDisplay = 'usd', btcPrice?
   return new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(v);
 }
 
-function formatPercent(v?: number) {
+function formatPercent(v?: number | string) {
   if (v == null) return "-";
-  const decimals = v > 99.99 ? 0 : v > 9.99 ? 1 : 2;
-  return `${v.toFixed(decimals)}%`;
+  const n = typeof v === 'string' ? parseFloat(v) : v;
+  if (!isFinite(n)) return "-";
+  const decimals = n > 99.99 ? 0 : n > 9.99 ? 1 : 2;
+  return `${n.toFixed(decimals)}%`;
 }
 
 function getToken0Percentage(pool: PoolSummary): number {

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -64,11 +64,12 @@ export default function WalletDashboardPage() {
 
   const walletConnected = typeof connected === 'boolean' ? connected : isConnected;
 
-  // Redirect if not connected
-  if (!walletConnected) {
-    router.push('/');
-    return null;
-  }
+  // Redirect if not connected (must be in useEffect to avoid setState during render)
+  useEffect(() => {
+    if (!walletConnected) router.push('/');
+  }, [walletConnected, router]);
+
+  if (!walletConnected) return null;
 
   // Settings tab is rendered separately for responsive control
   const tabs = [

--- a/hooks/useAddLiquidityMutation.ts
+++ b/hooks/useAddLiquidityMutation.ts
@@ -465,6 +465,7 @@ export function useAddLiquidityMutation() {
           changeAddress: changeAddr,
           alkanesChangeAddress: alkanesChangeAddr,
           ordinalsStrategy: 'burn',
+          network,
         });
 
         console.log('[AddLiquidity] Called alkanesExecuteTyped (browser:', isBrowserWallet, ')');

--- a/hooks/useAmmHistory.ts
+++ b/hooks/useAmmHistory.ts
@@ -295,6 +295,8 @@ export function useInfiniteAmmTxHistory({
     enabled: enabled && isInitialized && !!network && !!provider,
     queryFn: async ({ pageParam }) => {
       if (!provider) return { items: [], nextPage: undefined, total: 0 };
+      // On devnet, the REST data API returns HTTP 400 — skip entirely
+      if (network === 'devnet') return { items: [], nextPage: undefined, total: 0 };
       const offset = pageParam * count;
 
       try {

--- a/hooks/useSandshrewProvider.ts
+++ b/hooks/useSandshrewProvider.ts
@@ -8,13 +8,15 @@ import { useAlkanesSDK } from '@/context/AlkanesSDKContext';
 import { extendProvider, ExtendedWebProvider } from '@/lib/alkanes/extendedProvider';
 
 export function useSandshrewProvider(): ExtendedWebProvider | null {
-  const { provider } = useAlkanesSDK();
+  const { provider, network } = useAlkanesSDK();
 
-  // Extend the provider with alkanesExecuteTyped method
+  // Extend the provider with alkanesExecuteTyped method.
+  // Inject network so execute.ts can reliably detect devnet without
+  // requiring every hook to pass network explicitly.
   const extendedProvider = useMemo(() => {
     if (!provider) return null;
-    return extendProvider(provider);
-  }, [provider]);
+    return extendProvider(provider, network);
+  }, [provider, network]);
 
   return extendedProvider;
 }

--- a/hooks/useSwapMutation.ts
+++ b/hooks/useSwapMutation.ts
@@ -440,6 +440,7 @@ export function useSwapMutation() {
           changeAddress: changeAddr,
           alkanesChangeAddress: alkanesChangeAddr,
           ordinalsStrategy: 'burn',
+          network,
         });
 
         console.log('[useSwapMutation] Called alkanesExecuteTyped (browser:', isBrowserWallet, ')');

--- a/lib/alkanes/execute.ts
+++ b/lib/alkanes/execute.ts
@@ -115,11 +115,18 @@ export async function alkanesExecuteTyped(
   // Detect devnet by checking if the fetch interceptor is installed (localhost:18888).
   // NOTE (2026-04-02): "Insufficient alkanes" on devnet is almost always stale IndexedDB
   // cache, NOT a detection bug. Use DevnetControlPanel "Clear & Reload" to reset state.
-  let isDevnet = false;
-  try {
-    const rpcUrl = (provider as any).sandshrew_rpc_url?.();
-    isDevnet = typeof rpcUrl === 'string' && rpcUrl.includes('localhost:18888');
-  } catch { /* not devnet */ }
+  let isDevnet = params.network === 'devnet';
+  if (!isDevnet) {
+    try {
+      const rpcUrl = (provider as any).sandshrew_rpc_url?.();
+      isDevnet = typeof rpcUrl === 'string' && rpcUrl.includes('localhost:18888');
+    } catch { /* not devnet */ }
+  }
+  if (!isDevnet && typeof window !== 'undefined') {
+    try {
+      isDevnet = localStorage.getItem('subfrost_selected_network') === 'devnet';
+    } catch { /* ignore */ }
+  }
 
   if (isDevnet && typeof (provider as any).alkanesExecuteFull === 'function') {
     // Force mine_enabled + auto_confirm for devnet so alkanesExecuteFull

--- a/lib/alkanes/extendedProvider.ts
+++ b/lib/alkanes/extendedProvider.ts
@@ -105,11 +105,13 @@ export interface ExtendedWebProvider extends WebProvider {
 }
 
 /**
- * Extend a WebProvider with the alkanesExecuteTyped method
+ * Extend a WebProvider with the alkanesExecuteTyped method.
+ * When network is provided, it's injected into every call so execute.ts
+ * can reliably detect devnet without each hook passing it explicitly.
  */
-export function extendProvider(provider: WebProvider): ExtendedWebProvider {
+export function extendProvider(provider: WebProvider, network?: string): ExtendedWebProvider {
   const extended = provider as ExtendedWebProvider;
   extended.alkanesExecuteTyped = (params: AlkanesExecuteTypedParams) =>
-    alkanesExecuteTyped(provider, params);
+    alkanesExecuteTyped(provider, { ...params, network: params.network ?? network });
   return extended;
 }

--- a/lib/alkanes/types.ts
+++ b/lib/alkanes/types.ts
@@ -26,4 +26,6 @@ export interface AlkanesExecuteTypedParams {
    *  - 'burn': spend inscribed UTXOs without protection (destroys inscriptions)
    */
   ordinalsStrategy?: 'exclude' | 'preserve' | 'burn';
+  /** Network name — used to reliably detect devnet (instead of URL sniffing). */
+  network?: string;
 }

--- a/lib/devnet/boot.ts
+++ b/lib/devnet/boot.ts
@@ -262,6 +262,19 @@ export async function bootDevnetWithWasms(
 
   // Derive addresses using coinType=1 for regtest — matching the WASM provider's
   // walletLoadMnemonic. WalletContext also overrides to coinType=1 on devnet.
+  //
+  // ⚠️ ADDRESS MISMATCH WARNING:
+  // The WASM provider (walletLoadMnemonic) uses coinType=1 for regtest derivation.
+  // The JS SDK (createWalletFromMnemonic in WalletContext) uses coinType=0 always.
+  // These produce DIFFERENT addresses from the same mnemonic.
+  //
+  // Boot.ts MUST use coinType=1 here because the WASM provider's alkanesExecuteFull
+  // resolves from_addresses against its internal keystore (coinType=1). Using coinType=0
+  // causes "Address not found in keystore" errors on every transaction.
+  //
+  // WalletContext overrides to coinType=1 on devnet so UI addresses match boot.
+  // Boot-seeded state (orders, LP, tokens) lives at coinType=1 addresses.
+  // DO NOT change to coinType=0 — breaks WASM keystore resolution.
   const bitcoin = await import('bitcoinjs-lib');
   bitcoin.initEccLib(ecc);
   const network = bitcoin.networks.regtest;

--- a/lib/devnet/boot.ts
+++ b/lib/devnet/boot.ts
@@ -260,35 +260,11 @@ export async function bootDevnetWithWasms(
   });
   _provider.walletLoadMnemonic(mnemonic, null);
 
-  // Derive addresses
+  // Derive addresses using coinType=1 for regtest — matching the WASM provider's
+  // walletLoadMnemonic. WalletContext also overrides to coinType=1 on devnet.
   const bitcoin = await import('bitcoinjs-lib');
   bitcoin.initEccLib(ecc);
   const network = bitcoin.networks.regtest;
-  // coinType=1 for regtest — matches the WASM provider's walletLoadMnemonic.
-  //
-  // ⚠️ ADDRESS MISMATCH WARNING:
-  // The WASM provider (walletLoadMnemonic) uses coinType=1 for regtest derivation.
-  // The JS SDK (createWalletFromMnemonic in WalletContext) uses coinType=0 always.
-  // These produce DIFFERENT addresses from the same mnemonic.
-  //
-  // Boot.ts MUST use coinType=1 here because the WASM provider's alkanesExecuteFull
-  // resolves from_addresses against its internal keystore (coinType=1). Using coinType=0
-  // causes "Address not found in keystore" errors on every transaction.
-  //
-  // The connected wallet in WalletContext uses coinType=0 addresses. This means boot-seeded
-  // state (orders, positions, history) belongs to coinType=1 addresses — different from the
-  // UI's connected wallet. For seeded state to appear in the UI, the UI's data queries
-  // (Global Trades, Positions) must query ALL addresses, not just the connected wallet's.
-  //
-  // Open Orders: uses opcode 25 (GetUserOrders) which is caller-based in simulate context.
-  //   The simulate context uses the WASM provider's address (coinType=1), which matches boot.
-  // My Activity: uses dataApiGetAllAddressAmmTxHistory(address) — queries connected wallet
-  //   (coinType=0), so boot-seeded activity WON'T show here. Only user-initiated actions will.
-  // Global Trades: uses dataApiGetAllAmmTxHistory (no address filter) — shows ALL trades
-  //   regardless of which wallet made them. Boot-seeded swaps WILL show here.
-  // Positions: uses dataApiGetAlkanesByAddress — queries connected wallet (coinType=0).
-  //   Boot-seeded LP positions are at coinType=1 addresses, so they WON'T show here
-  //   unless the user adds liquidity themselves.
   const segwitChild = root.derivePath("m/84'/1'/0'/0/0");
   const taprootChild = root.derivePath("m/86'/1'/0'/0/0");
   const segwitPayment = bitcoin.payments.p2wpkh({
@@ -304,12 +280,8 @@ export async function bootDevnetWithWasms(
   const taprootAddress = taprootPayment.address!;
   _bootAddresses = { segwit: segwitAddress, taproot: taprootAddress };
 
-  // Log addresses for debugging. These are coinType=1 (WASM provider) addresses.
-  // The connected wallet in WalletContext uses coinType=0 addresses (different).
-  // Global Trades + Orderbook show boot data. Positions + My Activity don't.
-  // See CLAUDE.md "Address Derivation — Two CoinType Systems" for full context.
-  console.log('[devnet-boot] Boot wallet (coinType=1) segwit:', segwitAddress);
-  console.log('[devnet-boot] Boot wallet (coinType=1) taproot:', taprootAddress);
+  console.log('[devnet-boot] Boot wallet segwit:', segwitAddress);
+  console.log('[devnet-boot] Boot wallet taproot:', taprootAddress);
 
   // =========================================================================
   // Full protocol deployment — only on FRESH boot (no saved state).

--- a/queries/account.ts
+++ b/queries/account.ts
@@ -375,12 +375,38 @@ export function alkaneBalanceQueryOptions(deps: AlkaneBalanceDeps) {
 
       for (const address of addresses) {
         try {
-          // SDK data API — on mainnet this hits Espo server, on devnet this routes
-          // through the fetch interceptor to the espo tertiary indexer WASM
-          // (subfrost/espo kungfuflex/fujin branch, loaded as quspo.wasm).
-          const result = await (provider as any).dataApiGetAlkanesByAddress(address);
-          const items: any[] = result?.data || [];
-          console.log(`[alkaneBalanceQuery] ${address.slice(0, 12)}...: ${items.length} alkanes (dataApi)`);
+          // On devnet, REST data API returns HTTP 400. Use RPC fallback instead.
+          let items: any[] = [];
+          if (deps.network === 'devnet') {
+            const rpcResp = await fetch('http://localhost:18888', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                jsonrpc: '2.0', id: 1,
+                method: 'alkanes_protorunesbyaddress',
+                params: [{ address, protocolTag: '1' }],
+              }),
+            });
+            const rpcJson = await rpcResp.json();
+            const outpoints = rpcJson?.result?.outpoints || [];
+            for (const outpoint of outpoints) {
+              const balances = outpoint.balance_sheet?.cached?.balances || outpoint.runes || [];
+              for (const entry of balances) {
+                const block = entry.block ?? '0';
+                const tx = entry.tx ?? '0';
+                items.push({
+                  alkaneId: { block: String(block), tx: String(tx) },
+                  name: '', symbol: '',
+                  balance: String(entry.amount || '0'),
+                });
+              }
+            }
+            console.log(`[alkaneBalanceQuery] ${address.slice(0, 12)}...: ${items.length} alkanes (RPC fallback)`);
+          } else {
+            const result = await (provider as any).dataApiGetAlkanesByAddress(address);
+            items = result?.data || [];
+            console.log(`[alkaneBalanceQuery] ${address.slice(0, 12)}...: ${items.length} alkanes (dataApi)`);
+          }
 
           for (const item of items) {
             const block = item.alkaneId?.block;
@@ -499,44 +525,30 @@ export function sellableCurrenciesQueryOptions(deps: SellableCurrenciesDeps) {
             // This powers the 25/50/75/MAX percentage buttons on the swap page.
             let balances: { alkaneId: string; balance: string; name?: string; symbol?: string }[] = [];
 
-            if (deps.network === 'devnet' && deps.provider) {
-              // Same quspo bug as alkaneBalanceQueryOptions — try quspo first,
-              // fall back to enriched balance extraction when quspo returns empty.
-              const result = await (deps.provider as any).dataApiGetAlkanesByAddress(address);
-              const items: any[] = result?.data || [];
-              for (const item of items) {
-                const block = item.alkaneId?.block;
-                const tx = item.alkaneId?.tx;
-                if (block == null || tx == null) continue;
-                balances.push({
-                  alkaneId: `${block}:${tx}`,
-                  balance: String(item.balance || '0'),
-                  name: item.name || undefined,
-                  symbol: item.symbol || undefined,
-                });
-              }
-              // Quspo empty fallback: extract from enriched balances
-              if (balances.length === 0) {
-                try {
-                  const enriched = await deps.provider.getEnrichedBalances(address, '1');
-                  const mapToObj = (v: any): any => {
-                    if (v instanceof Map) { const o: any = {}; for (const [k, val] of v.entries()) o[k] = mapToObj(val); return o; }
-                    if (Array.isArray(v)) return v.map(mapToObj);
-                    return v;
-                  };
-                  const returns = enriched instanceof Map ? mapToObj(enriched.get('returns')) : mapToObj(enriched?.returns || enriched);
-                  for (const asset of (returns?.assets || [])) {
-                    for (const r of (asset?.runes || [])) {
-                      const known = KNOWN_TOKENS_SELL[`${r.block}:${r.tx}`];
-                      balances.push({
-                        alkaneId: `${r.block}:${r.tx}`,
-                        balance: String(r.amount || '0'),
-                        name: known?.name,
-                        symbol: known?.symbol,
-                      });
-                    }
-                  }
-                } catch {}
+            if (deps.network === 'devnet') {
+              // REST data API returns HTTP 400 on devnet. Use RPC directly.
+              const rpcResp = await fetch('http://localhost:18888', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  jsonrpc: '2.0', id: 1,
+                  method: 'alkanes_protorunesbyaddress',
+                  params: [{ address, protocolTag: '1' }],
+                }),
+              });
+              const rpcJson = await rpcResp.json();
+              const outpoints = rpcJson?.result?.outpoints || [];
+              for (const outpoint of outpoints) {
+                const entries = outpoint.balance_sheet?.cached?.balances || outpoint.runes || [];
+                for (const entry of entries) {
+                  const known = KNOWN_TOKENS_SELL[`${entry.block}:${entry.tx}`];
+                  balances.push({
+                    alkaneId: `${entry.block}:${entry.tx}`,
+                    balance: String(entry.amount || '0'),
+                    name: known?.name,
+                    symbol: known?.symbol,
+                  });
+                }
               }
             } else {
               const resp = await fetch(


### PR DESCRIPTION
  - Devnet detection fix: alkanesExecuteFull wasn't used on devnet because sandshrew_rpc_url() detection was unreliable — added localStorage
  fallback so all mutation hooks automatically route through the primary indexer instead of broken REST/quspo path
  - Add liquidity working on devnet: passed network param explicitly to execute layer; fixes "Insufficient alkanes: need X, have 0" when
  balance exists
  - Skip AMM history REST calls on devnet: quspo returns HTTP 400, now returns empty instead of error-spamming console
  - MarketsGrid crash fix: formatPercent handled string values from pool data causing toFixed is not a function
  - React render warning fix: moved router.push redirect out of render into useEffect in wallet page
  - Boot.ts cleanup: simplified address derivation comments (no functional change, coinType=1 retained)