### PR TITLE
phase 2: route BTC price + token-pair reads through rpc.ts

### DIFF
--- a/hooks/useAlkanesTokenPairs.ts
+++ b/hooks/useAlkanesTokenPairs.ts
@@ -41,6 +41,7 @@ import { useAlkanesSDK } from '@/context/AlkanesSDKContext';
 import { useWallet } from '@/context/WalletContext';
 import { KNOWN_TOKENS } from '@/lib/alkanes-client';
 import { queryKeys } from '@/queries/keys';
+import { getTokenPairs as rpcGetTokenPairs } from '@/lib/alkanes/rpc';
 
 export type AlkanesTokenPair = {
   token0: { id: string; token0Amount?: string; alkaneId?: { block: number | string; tx: number | string } };
@@ -146,30 +147,41 @@ async function fetchPoolsFromSDK(
 
   let poolsArray: any[] = [];
 
-  // Method 1: Direct REST call to get-all-token-pairs
-  // On devnet, the fetch interceptor routes this to the espo tertiary indexer.
-  if (poolsArray.length === 0 ) {
+  // Method 1: rpc.getTokenPairs — hedged primary (same REST endpoint as before)
+  // with alkanode fallback. Behavior-equivalent to prior direct fetch for the
+  // primary path. On devnet the fetch interceptor still routes through espo.
+  if (poolsArray.length === 0) {
     try {
-      const [block, tx] = factoryId.split(':');
-      const response = await withTimeout(
-        fetch(`${getRpcUrl(network)}/get-all-token-pairs`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ factoryId: { block, tx } }),
-        }),
+      const pools = await withTimeout(
+        rpcGetTokenPairs(network, factoryId),
         15000,
-        'direct-get-all-token-pairs'
+        'rpc.getTokenPairs',
       );
-      const result = await response.json();
-      console.log('[useAlkanesTokenPairs] Direct REST result:', JSON.stringify(result)?.slice(0, 300));
-      const pools = normalizePoolArray(result);
-      console.log('[useAlkanesTokenPairs] Direct REST normalized pools count:', pools.length);
-      if (pools.length > 0) {
-        poolsArray = pools.map(toPoolRow);
-        console.log('[useAlkanesTokenPairs] Direct REST returned', poolsArray.length, 'pools');
+      // rpc.getTokenPairs returns Record<string, AmmPoolData>; convert to the
+      // shape normalizePoolArray expects (array of rows) so `toPoolRow` downstream
+      // can unify it with the other methods.
+      const arr = Object.entries(pools).map(([poolId, data]) => {
+        const [pb, pt] = poolId.split(':');
+        const [tab, tat] = (data.base || ':').split(':');
+        const [tbb, tbt] = (data.quote || ':').split(':');
+        return {
+          pool_block_id: pb,
+          pool_tx_id: pt,
+          token0_block_id: tab,
+          token0_tx_id: tat,
+          token1_block_id: tbb,
+          token1_tx_id: tbt,
+          token0_amount: data.base_reserve,
+          token1_amount: data.quote_reserve,
+        };
+      });
+      const normalized = normalizePoolArray(arr);
+      if (normalized.length > 0) {
+        poolsArray = normalized.map(toPoolRow);
+        console.log('[useAlkanesTokenPairs] rpc.getTokenPairs returned', poolsArray.length, 'pools');
       }
     } catch (e) {
-      console.warn('[useAlkanesTokenPairs] Direct REST get-all-token-pairs failed:', e);
+      console.warn('[useAlkanesTokenPairs] rpc.getTokenPairs failed:', e);
     }
   }
 

--- a/lib/alkanes/__tests__/rpc.test.ts
+++ b/lib/alkanes/__tests__/rpc.test.ts
@@ -222,11 +222,15 @@ describe('rpc.ts — unit (mock fetch)', () => {
       json: async () => ({ pools: { '2:77087': { base: '2:0', base_reserve: '1', quote: '32:0', quote_reserve: '2', source: 'live' } } }),
     } as Response);
 
-    const pairs = await getTokenPairs('mainnet');
+    const pairs = await getTokenPairs('mainnet', '4:65498');
 
     expect(pairs['2:77087']).toBeDefined();
     // Only the primary source should have been called — fallback stays cold.
     expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    // Body contains factoryId split into block/tx
+    const body = JSON.parse(init.body);
+    expect(body.factoryId).toEqual({ block: '4', tx: '65498' });
   });
 });
 

--- a/lib/alkanes/rpc.ts
+++ b/lib/alkanes/rpc.ts
@@ -351,16 +351,26 @@ export interface TokenPair {
  * Fetch all token pairs discoverable from the app's own REST proxy.
  * Routes through `/api/rpc/{network}/get-all-token-pairs` (existing app endpoint).
  *
+ * The upstream REST endpoint expects a body `{ factoryId: { block, tx } }`.
+ * `factoryId` is passed as `"block:tx"` and split internally.
+ *
  * Hedged with `getAllAmmPools` since that returns the same information in a
  * different shape. Normalized here so callers can `.pools` directly.
  */
 export async function getTokenPairs(
   network: string,
+  factoryId: string,
   signal?: AbortSignal,
 ): Promise<Record<string, AmmPoolData>> {
+  const [block, tx] = factoryId.split(':');
   // Primary: REST endpoint the app already maintains. Fast on subfrost networks.
   const primary = async (s: AbortSignal) => {
-    const res = await fetch(`${getRpcUrl(network)}/get-all-token-pairs`, { signal: s });
+    const res = await fetch(`${getRpcUrl(network)}/get-all-token-pairs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ factoryId: { block, tx } }),
+      signal: s,
+    });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const json = await res.json();
     // Normalize whatever shape the server returned into `ammdata.get_pools` format.

--- a/queries/market.ts
+++ b/queries/market.ts
@@ -9,6 +9,7 @@ import { queryOptions } from '@tanstack/react-query';
 import { queryKeys } from './keys';
 import { FRBTC_WRAP_FEE_PER_1000, FRBTC_UNWRAP_FEE_PER_1000 } from '@/constants/alkanes';
 import { encodeSimulateCalldata } from '@/utils/simulateCalldata';
+import { getBitcoinPrice as rpcGetBitcoinPrice } from '@/lib/alkanes/rpc';
 // Pricing data is global — always use mainnet subpricer regardless of connected network
 const SUBPRICER_BASE = 'https://mainnet.subfrost.io/v4/subfrost';
 
@@ -63,19 +64,15 @@ export function btcPriceQueryOptions(
           const price = data?.usd ?? data?.price ?? 0;
           if (price > 0) return price;
         }
-      } catch { /* fall through to SDK */ }
+      } catch { /* fall through to rpc layer */ }
 
-      // Fallback: SDK data API
-      if (!provider) return 90000;
+      // Fallback: rpc.ts (Next.js /api/btc-price route).
+      // Replaces the previous WASM call `provider.dataApiGetBitcoinPrice()` —
+      // same upstream data, no WASM roundtrip. `provider` arg kept for hook API
+      // backwards compat but no longer used in this branch.
       try {
-        const response = await provider.dataApiGetBitcoinPrice();
-        const price =
-          typeof response === 'number'
-            ? response
-            : (response as { usd?: number; price?: number })?.usd ??
-              (response as { price?: number })?.price ??
-              0;
-        return price > 0 ? price : 90000;
+        const { usd } = await rpcGetBitcoinPrice();
+        return usd > 0 ? usd : 90000;
       } catch {
         return 90000;
       }


### PR DESCRIPTION
## Summary

Phase 2 — migrates the first two read paths onto \`lib/alkanes/rpc.ts\`. Behavior-preserving; no change to primary URLs or upstream endpoints.

Stacked on #57.

## Changes

### \`queries/market.ts — btcPriceQueryOptions\`
- Replace \`provider.dataApiGetBitcoinPrice()\` fallback with \`rpc.getBitcoinPrice()\`
- Same upstream data (existing \`/api/btc-price\` Next.js route), no WASM roundtrip
- Subpricer primary path unchanged
- \`provider\` still guards \`enabled\` — kept in signature for backwards compat

### \`hooks/useAlkanesTokenPairs.ts\`
- Replace Method 1 (direct fetch) with \`rpc.getTokenPairs(network, factoryId)\`
- Same primary URL + body (\`{ factoryId: { block, tx } }\`)
- Adds hedged alkanode fallback for free (2s delay)
- Methods 2, 2b, 3 (WASM SDK fallbacks) **retained** as safety net; removed in Phase 7

### \`lib/alkanes/rpc.ts\`
- \`getTokenPairs(network, factoryId, signal?)\` now requires \`factoryId\`
- Posts correct body shape to match existing REST endpoint

## Verification

- ✅ \`tsc --noEmit\`
- ✅ \`pnpm run test:unit\`: 335 / 11,570 — byte-identical to Phase 1 baseline
- ✅ Same 3 pre-existing \`.claude/worktrees/*\` failures
- ✅ WASM pin MD5 \`4b936b89a3a8c4500639e78de7934133\` unchanged
- ✅ rpc.ts unit test count grew by 0 (updated existing test to assert new factoryId body)

## Test plan

- [x] Unit tests pass
- [x] Type check clean
- [ ] Dev server smoke: \`pnpm dev\` → Swap page loads pool list normally
- [ ] Inspect Network tab: \`/api/rpc/{network}/get-all-token-pairs\` called with factoryId body

🤖 Generated with [Claude Code](https://claude.com/claude-code)