### PR TITLE
phase 3: consolidate alkaneRpc helpers + frBTC premium through rpc.ts

### DIFF
--- a/queries/market.ts
+++ b/queries/market.ts
@@ -9,7 +9,7 @@ import { queryOptions } from '@tanstack/react-query';
 import { queryKeys } from './keys';
 import { FRBTC_WRAP_FEE_PER_1000, FRBTC_UNWRAP_FEE_PER_1000 } from '@/constants/alkanes';
 import { encodeSimulateCalldata } from '@/utils/simulateCalldata';
-import { getBitcoinPrice as rpcGetBitcoinPrice } from '@/lib/alkanes/rpc';
+import { getBitcoinPrice as rpcGetBitcoinPrice, alkanesSimulate as rpcAlkanesSimulate } from '@/lib/alkanes/rpc';
 // Pricing data is global — always use mainnet subpricer regardless of connected network
 const SUBPRICER_BASE = 'https://mainnet.subfrost.io/v4/subfrost';
 
@@ -123,22 +123,27 @@ export function frbtcPremiumQueryOptions(
       try {
         const frbtcId = parseAlkaneId(frbtcAlkaneId);
         const contractId = `${frbtcId.block}:${frbtcId.tx}`;
-        const context = JSON.stringify({
-          alkanes: [],
-          calldata: encodeSimulateCalldata(contractId, [104]),
-          height: 1000000,
-          txindex: 0,
-          pointer: 0,
-          refund_pointer: 0,
-          vout: 0,
-          transaction: [],
-          block: [],
-        });
 
-        const result = await provider.alkanesSimulate(contractId, context, 'latest');
+        // Server derives the MessageContextParcel from `target + inputs`;
+        // no need to encode calldata client-side. Verified live 2026-04-18
+        // that `alkanes_simulate` with `inputs:["104"]` returns the same
+        // 16-byte u128 GET_PREMIUM result as the calldata form.
+        const result = await rpcAlkanesSimulate(network, {
+          target: contractId,
+          inputs: ['104'],
+          height: '1000000',
+        });
         if (!result?.execution?.data) throw new Error('No response data');
 
-        const premium = parseU128FromBytes(result.execution.data);
+        // `data` is a "0x"-prefixed hex string; parseU128FromBytes accepts
+        // either a hex string (via Uint8Array) or a raw byte array. Convert
+        // once here so the helper keeps its existing contract.
+        const hex = (result.execution.data as string).replace(/^0x/, '');
+        const bytes = new Uint8Array(hex.length / 2);
+        for (let i = 0; i < bytes.length; i++) {
+          bytes[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        const premium = parseU128FromBytes(bytes);
         const feePerThousand = Number(premium) / 100_000;
 
         return {

--- a/utils/alkaneRpc.ts
+++ b/utils/alkaneRpc.ts
@@ -2,11 +2,15 @@
  * Shared utilities for alkanes RPC calls.
  *
  * All hooks that query contract state or token balances should use these
- * helpers instead of raw fetch(). This ensures consistent error handling,
- * response validation, and abort support.
+ * helpers. Internally delegates to `lib/alkanes/rpc.ts` — the single
+ * fetch-layer source of truth. This file is kept as a thin compatibility
+ * shim so its 4 call sites don't need to change during the migration.
+ *
+ * Phase 3 of the ts-sdk minimization plan (2026-04-18): consolidated
+ * duplicate `alkanes_protorunesbyaddress` + `alkanes_simulate` implementations.
  */
 
-import { getRpcUrl } from '@/utils/getConfig';
+import { alkanesSimulate, getProtorunesByAddress } from '@/lib/alkanes/rpc';
 
 // Factory-created alkanes (NFT receipts, LP tokens) are always at block 2
 export const ALKANE_FACTORY_BLOCK = 2;
@@ -36,32 +40,19 @@ export async function simulateCall(
   inputs: string[],
   signal?: AbortSignal,
 ): Promise<{ data: string; error: string | null }> {
-  const rpcUrl = getRpcUrl(network);
-  const resp = await fetch(rpcUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+  const result = await alkanesSimulate(
+    network,
+    {
+      target: `${targetBlock}:${targetTx}`,
+      inputs,
+      height: '999',
+    },
     signal,
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      method: 'alkanes_simulate',
-      params: [{
-        target: { block: targetBlock, tx: targetTx },
-        inputs,
-        alkanes: [],
-        transaction: '0x',
-        block: '0x',
-        height: '999',
-        txindex: 0,
-        vout: 0,
-      }],
-      id: 1,
-    }),
-  });
-  if (!resp.ok) throw new Error(`RPC HTTP ${resp.status}`);
-  const json = await resp.json();
-  const error = json?.result?.execution?.error || null;
-  const data = (json?.result?.execution?.data || '').replace('0x', '');
-  return { data, error };
+  );
+  return {
+    data: (result.execution?.data || '').replace('0x', ''),
+    error: result.execution?.error ?? null,
+  };
 }
 
 export interface AlkaneToken {
@@ -79,27 +70,17 @@ export async function queryAlkanesAtAddress(
   address: string,
   signal?: AbortSignal,
 ): Promise<AlkaneToken[]> {
-  const rpcUrl = getRpcUrl(network);
-  const resp = await fetch(rpcUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    signal,
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      method: 'alkanes_protorunesbyaddress',
-      params: [{ address, protocolTag: '1' }],
-      id: 1,
-    }),
-  });
-  if (!resp.ok) throw new Error(`RPC HTTP ${resp.status}`);
-  const json = await resp.json();
+  const response = await getProtorunesByAddress(network, address, signal);
   const tokens: AlkaneToken[] = [];
-  for (const outpoint of json?.result?.outpoints || []) {
-    const balances = outpoint.balance_sheet?.cached?.balances || outpoint.runes || [];
+  for (const outpoint of response?.outpoints || []) {
+    const balances =
+      outpoint.balance_sheet?.cached?.balances ||
+      (outpoint as unknown as { runes?: { block: number; tx: number; amount: string }[] }).runes ||
+      [];
     for (const entry of balances) {
       tokens.push({
-        block: parseInt(entry.block ?? '0', 10),
-        tx: parseInt(entry.tx ?? '0', 10),
+        block: parseInt(String(entry.block ?? '0'), 10),
+        tx: parseInt(String(entry.tx ?? '0'), 10),
         amount: BigInt(entry.amount || '0'),
       });
     }


### PR DESCRIPTION
## Summary

Phase 3 — consolidates two parallel implementations of \`alkanes_simulate\` and \`alkanes_protorunesbyaddress\` into \`lib/alkanes/rpc.ts\`.

Stacked on #58.

## Changes

### \`utils/alkaneRpc.ts\`
- \`simulateCall\` and \`queryAlkanesAtAddress\` now delegate to \`lib/alkanes/rpc.ts\`
- File kept as thin compatibility shim — its 4 call sites don't change
- Eliminates duplicate JSON-RPC construction (was two parallel impls)

### \`queries/market.ts — frbtcPremiumQueryOptions\`
- Replace WASM \`provider.alkanesSimulate(contractId, context, 'latest')\` with direct-fetch \`rpc.alkanesSimulate(network, { target, inputs, height })\`
- Server derives the MessageContextParcel from target + inputs; no client-side \`encodeSimulateCalldata\` needed
- Live-verified 2026-04-18: \`target=32:0 inputs=[\"104\"]\` returns the same 16-byte u128 as the prior calldata form (\`0xa0860100...\` = 100_000 LE)
- \`encodeSimulateCalldata\` import retained for OTHER queryFns in the same file (migrated in Phase 4)

### NOT touched
- \`hooks/useOrderbook.ts\` — heavy diagnostic code paths, touched in Phase 4 or later
- \`hooks/useUserOrders.ts\`, \`hooks/fire/*\`, \`hooks/useLpTokenId.ts\` — all consume \`utils/alkaneRpc.ts\`, so they benefit transitively with zero caller change

## Verification

- ✅ \`tsc --noEmit\`
- ✅ \`useFrbtcPremium.vitest.test.ts\`: 132 / 132
- ✅ \`pnpm run test:unit\`: 335 / 11,570 — byte-identical to Phase 2 baseline
- ✅ Same 3 pre-existing \`.claude/worktrees/*\` failures
- ✅ WASM pin MD5 \`4b936b89a3a8c4500639e78de7934133\` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)