### PR TITLE
phase 4: parallelize Fujin markets + lazy-load CandleChart

### DIFF
--- a/app/swap/components/PriceChartCard.tsx
+++ b/app/swap/components/PriceChartCard.tsx
@@ -1,10 +1,14 @@
 'use client';
 
 import { useState } from 'react';
+import dynamic from 'next/dynamic';
 import type { PoolSummary } from "../types";
 import TokenIcon from "@/app/components/TokenIcon";
 import { useWallet } from "@/context/WalletContext";
-import CandleChart from "./CandleChart";
+// CandleChart statically imports lightweight-charts (~140 KB gz). Keep it off
+// the initial swap-page bundle — it only renders when a pool is selected and
+// the user opens the chart. Defer loading until it's actually mounted.
+const CandleChart = dynamic(() => import('./CandleChart'), { ssr: false });
 import { useBtcUsdtCandles, type CandleTimeframe } from '@/hooks/usePoolCandles';
 
 type Props = {

--- a/hooks/useFujinMarkets.ts
+++ b/hooks/useFujinMarkets.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useWallet } from '@/context/WalletContext';
-import { getConfig, getRpcUrl } from '@/utils/getConfig';
+import { getConfig } from '@/utils/getConfig';
+import { alkanesSimulate as rpcAlkanesSimulate } from '@/lib/alkanes/rpc';
 
 export interface FujinMarket {
   marketId: string;
@@ -42,34 +43,6 @@ function parseNumMarkets(data: string | number[]): number {
 }
 
 /**
- * Parse GetAllMarkets (opcode 3) response — returns a list of market AlkaneIds
- * Format: u128 count, then count * (u128 block, u128 tx) pairs
- */
-function parseMarketsList(data: string | number[]): FujinMarket[] {
-  const bytes = typeof data === 'string'
-    ? Array.from(Buffer.from(data.replace(/^0x/, ''), 'hex'))
-    : data;
-  if (bytes.length < 16) return [];
-
-  const count = Number(readU128LE(bytes, 0));
-  const markets: FujinMarket[] = [];
-  let offset = 16;
-
-  for (let i = 0; i < count && offset + 32 <= bytes.length; i++) {
-    const block = Number(readU128LE(bytes, offset));
-    const tx = Number(readU128LE(bytes, offset + 16));
-    markets.push({
-      marketId: `${block}:${tx}`,
-      block,
-      tx,
-    });
-    offset += 32;
-  }
-
-  return markets;
-}
-
-/**
  * Queries MasterFujin [4:7112] for market count and list.
  *
  * MasterFujin opcodes (from reference/Fujin-contracts/alkanes/fujin-master/src/lib.rs):
@@ -87,28 +60,19 @@ export function useFujinMarkets() {
 
   return useQuery<FujinMarketsResult | null>({
     queryKey: ['fujin-markets', network],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const config = getConfig(network || 'devnet');
       // Use MasterFujin (market registry), not factory logic (uninitialized template)
       const masterId = (config as any).FUJIN_MASTER_ID || (config as any).FUJIN_FACTORY_ID;
       if (!masterId) return null;
 
-      const [block, tx] = masterId.split(':');
-      const target = { block, tx };
-
       // MasterFujin opcode 91: GetMarketCount → u128
-      const numResp = await fetch(getRpcUrl(network), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'alkanes_simulate',
-          params: [{ target, inputs: ['91'], alkanes: [], transaction: '0x', block: '0x', height: '999999', txindex: 0, vout: 0 }],
-          id: 1,
-        }),
-      });
-      const numData = await numResp.json();
-      const numExec = numData?.result?.execution;
+      const numRes = await rpcAlkanesSimulate(
+        network,
+        { target: masterId, inputs: ['91'], height: '999999' },
+        signal,
+      );
+      const numExec = numRes.execution;
 
       if (numExec?.error) {
         return { factoryId: masterId, markets: [], numMarkets: 0, error: numExec.error };
@@ -120,40 +84,40 @@ export function useFujinMarkets() {
         return { factoryId: masterId, markets: [], numMarkets: 0, error: null };
       }
 
-      // MasterFujin opcode 93: GetAllMarkets → market list
-      // Response format differs from factory — each entry is (base_token_block, base_token_tx, duration)
-      // For now, query each market individually via opcode 92 (GetMarketAtIndex)
-      let markets: FujinMarket[] = [];
-      try {
-        for (let i = 0; i < numMarkets && i < 20; i++) {
-          const idxResp = await fetch(getRpcUrl(network), {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              jsonrpc: '2.0',
-              method: 'alkanes_simulate',
-              params: [{ target, inputs: ['92', String(i)], alkanes: [], transaction: '0x', block: '0x', height: '999999', txindex: 0, vout: 0 }],
-              id: 2 + i,
-            }),
+      // MasterFujin opcode 92: GetMarketAtIndex. Parallelize — server doesn't
+      // support JSON-RPC batch arrays, so we use Promise.all instead. The
+      // per-index calls are independent reads so the AbortSignal is shared
+      // to cancel all in-flight requests on unmount.
+      const indicesToFetch = Math.min(numMarkets, 20);
+      const marketResponses = await Promise.all(
+        Array.from({ length: indicesToFetch }, (_, i) =>
+          rpcAlkanesSimulate(
+            network,
+            { target: masterId, inputs: ['92', String(i)], height: '999999' },
+            signal,
+          ).catch((err) => {
+            console.warn(`[useFujinMarkets] index ${i} failed:`, err);
+            return null;
+          }),
+        ),
+      );
+
+      const markets: FujinMarket[] = [];
+      for (const res of marketResponses) {
+        const idxExec = res?.execution;
+        if (!idxExec?.data || idxExec.error) continue;
+        const hex = idxExec.data.replace(/^0x/, '');
+        // GetMarketAtIndex returns: base_token(32 bytes) + duration(16 bytes) = 80 bytes
+        if (hex.length >= 80) {
+          const bytes = Array.from(Buffer.from(hex, 'hex'));
+          const baseBlock = Number(readU128LE(bytes, 0));
+          const baseTx = Number(readU128LE(bytes, 16));
+          markets.push({
+            marketId: `${baseBlock}:${baseTx}`,
+            block: baseBlock,
+            tx: baseTx,
           });
-          const idxData = await idxResp.json();
-          const idxExec = idxData?.result?.execution;
-          if (idxExec?.data && !idxExec.error) {
-            const hex = idxExec.data.replace(/^0x/, '');
-            // GetMarketAtIndex returns: base_token(32 bytes) + duration(16 bytes) = 80 bytes
-            if (hex.length >= 80) {
-              const baseBlock = Number(readU128LE(Array.from(Buffer.from(hex, 'hex')), 0));
-              const baseTx = Number(readU128LE(Array.from(Buffer.from(hex, 'hex')), 16));
-              markets.push({
-                marketId: `${baseBlock}:${baseTx}`,
-                block: baseBlock,
-                tx: baseTx,
-              });
-            }
-          }
         }
-      } catch (err) {
-        console.warn('[useFujinMarkets] Failed to fetch market list:', err);
       }
 
       return { factoryId: masterId, markets, numMarkets, error: null };


### PR DESCRIPTION
## Summary

Phase 4 — two small but measurable wins: parallelize a serial N+1 RPC loop, and keep a 140 KB gzipped chart library off the initial bundle.

Stacked on #59.

## Changes

### \`hooks/useFujinMarkets.ts\`
- Replace raw \`fetch → alkanes_simulate\` with \`rpc.alkanesSimulate\`
- Parallelize GetMarketAtIndex reads via \`Promise.all\` — was serial \`await fetch()\` loop
- Thread \`AbortSignal\` from TanStack Query → unmount cancels in-flight reads
- Remove dead \`parseMarketsList\` helper (opcode 93 path was never wired)

### \`app/swap/components/PriceChartCard.tsx\`
- Convert \`CandleChart\` to \`next/dynamic({ ssr: false })\`
- CandleChart statically imports \`lightweight-charts\` (~140 KB gz) — now loads only when user opens the chart

### Deferred to Phase 7
- \`usePoolCandles\`/\`usePoolCandleVolumes\`/\`usePoolEspoCandles\` — use WASM \`dataApiGetCandles\` (no verified REST)
- \`useLPPositions\`/\`usePositionMetadata\` — use WASM \`espoGetKeys\`/\`espoGetAlkaneInfo\`
- \`useOrderbook\` — heavy diagnostic paths; already uses \`Promise.all\` but via raw fetch

## Verification

- ✅ \`tsc --noEmit\`
- ✅ \`useFujinMarkets.test.ts\`: 48 / 48
- ✅ \`pnpm run test:unit\`: 335 / 11,570 — byte-identical to Phase 3 baseline
- ✅ Same 3 pre-existing \`.claude/worktrees/*\` failures
- ✅ WASM pin MD5 \`4b936b89a3a8c4500639e78de7934133\` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)