### PR TITLE
phase 5: keystore shim at @/lib/wallet/keystore

### DIFF
--- a/app/wallet/components/WalletSettings.tsx
+++ b/app/wallet/components/WalletSettings.tsx
@@ -5,7 +5,7 @@ import { useWallet } from '@/context/WalletContext';
 import { useTheme } from '@/context/ThemeContext';
 import { Network, Key, Save, Eye, EyeOff, Copy, Check, ChevronDown, ChevronUp, Download, Shield, Lock, Cloud, AlertTriangle, X, Settings } from 'lucide-react';
 import { initGoogleDrive, isDriveConfigured, backupWalletToDrive } from '@/utils/clientSideDrive';
-import { unlockKeystore } from '@alkanes/ts-sdk';
+import { unlockKeystore } from '@/lib/wallet/keystore';
 import { useTranslation } from '@/hooks/useTranslation';
 
 type NetworkType = 'mainnet' | 'signet' | 'regtest' | 'regtest-local' | 'subfrost-regtest' | 'oylnet' | 'devnet' | 'custom';

--- a/lib/oyl/alkanes/wallet-integration-real.ts
+++ b/lib/oyl/alkanes/wallet-integration-real.ts
@@ -9,8 +9,10 @@
 // Define Network type locally to avoid import issues with ts-sdk
 import type { Network } from '@/utils/constants';
 
-// Import from the browser-bundled alkanes SDK
-import { createKeystore, unlockKeystore, KeystoreManager } from '@alkanes/ts-sdk';
+// Keystore helpers are re-exported from @/lib/wallet/keystore — a shim that
+// lets us swap the implementation later without touching call sites. See
+// lib/wallet/keystore.ts for the migration rationale.
+import { createKeystore, unlockKeystore, KeystoreManager } from '@/lib/wallet/keystore';
 
 export type { Network };
 

--- a/lib/wallet/keystore.ts
+++ b/lib/wallet/keystore.ts
@@ -1,0 +1,40 @@
+/**
+ * Keystore shim — re-exports from @alkanes/ts-sdk.
+ *
+ * Phase 5 of the ts-sdk minimization plan.
+ *
+ * This file exists so app-level imports go through a local module we control.
+ * The SDK's keystore implementation (PBKDF2 + AES-GCM, ~500 LOC, pure TS
+ * depending only on @noble/hashes + bip39 which are already direct deps)
+ * is still the source of truth — we have not inlined it yet.
+ *
+ * ## Why a shim instead of an inline
+ *
+ * The SDK's keystore uses the same crypto primitives the WASM provider uses
+ * internally. Getting the PBKDF2 iteration count, salt format, or nonce
+ * handling wrong by a single byte produces keystores that decrypt with the
+ * same password to DIFFERENT mnemonics — silent data loss. Inlining is
+ * correct only when we can test byte-for-byte round-tripping against the SDK
+ * across a representative set of fixture keystores. Until then, delegate.
+ *
+ * ## Migration path
+ *
+ * When we do inline, every call site imports from `@/lib/wallet/keystore`
+ * and the change is confined to this file — no hook / context / component
+ * changes needed.
+ *
+ * ## Current call sites
+ *
+ * - `app/wallet/components/WalletSettings.tsx` — uses `unlockKeystore` for
+ *   password-protected mnemonic export
+ * - `lib/oyl/alkanes/wallet-integration-real.ts` — uses all three exports
+ *   for the wallet creation / import / unlock flow
+ */
+
+export {
+  createKeystore,
+  unlockKeystore,
+  KeystoreManager,
+} from '@alkanes/ts-sdk';
+
+export type { Keystore, WalletConfig } from '@alkanes/ts-sdk';


### PR DESCRIPTION
## Summary

Phase 5 — establishes a local import path for keystore helpers. Behavior-equivalent: SDK is still the implementation behind the shim.

Stacked on #60.

## Changes

- **New** `lib/wallet/keystore.ts` — re-exports \`createKeystore\`, \`unlockKeystore\`, \`KeystoreManager\`, \`Keystore\`, \`WalletConfig\` from \`@alkanes/ts-sdk\`
- \`app/wallet/components/WalletSettings.tsx\` — import path swap
- \`lib/oyl/alkanes/wallet-integration-real.ts\` — import path swap

## Why a shim, not a full inline

The SDK's keystore (504 LOC) uses the same crypto primitives the WASM provider uses internally. A PBKDF2 iteration / salt / nonce mismatch produces keystores that decrypt the same password to DIFFERENT mnemonics — silent data loss. Wrapping first, inlining later, means the migration happens in one file instead of two call sites scattered across features.

## Verification

- ✅ \`tsc --noEmit\`
- ✅ \`pnpm run test:unit\`: 335 / 11,570 — byte-identical to Phase 4 baseline
- ✅ Same 3 pre-existing \`.claude/worktrees/*\` failures (none in app source)
- ✅ WASM pin MD5 \`4b936b89a3a8c4500639e78de7934133\` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)