### PR TITLE
phase 6: local BrowserWalletInfo / WalletAccount types

### DIFF
--- a/constants/wallets.ts
+++ b/constants/wallets.ts
@@ -2,12 +2,16 @@
  * Browser wallet configuration with custom ordering.
  * Uses SDK wallet data (including base64 icons) with our preferred display order.
  * Wallets not in the SDK (oyl, tokeo, keplr) use local definitions.
+ *
+ * Phase 6 of the ts-sdk minimization plan: the `BrowserWalletInfo` type is now
+ * sourced from `@/types/browserWallet`, decoupling type callers from the SDK
+ * barrel. The runtime `BROWSER_WALLETS` array is still sourced from the SDK
+ * because it carries ~600 LOC of base64-encoded wallet icons that would bloat
+ * this repo for zero functional benefit.
  */
 
-import {
-  BROWSER_WALLETS as SDK_WALLETS,
-  type BrowserWalletInfo,
-} from '@alkanes/ts-sdk';
+import { BROWSER_WALLETS as SDK_WALLETS } from '@alkanes/ts-sdk';
+import type { BrowserWalletInfo } from '@/types/browserWallet';
 
 export type { BrowserWalletInfo };
 

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -54,11 +54,14 @@ import {
   // Browser wallet imports
   WalletConnector,
   ConnectedWallet,
-  BrowserWalletInfo,
   // Wallet adapter for signing
   createWalletAdapter,
   JsWalletAdapter,
 } from '@alkanes/ts-sdk';
+// BrowserWalletInfo sourced from the local type module (Phase 6 of
+// ts-sdk minimization). The shape must match the SDK's export byte-for-byte;
+// see types/browserWallet.ts for the drift-safety comment.
+import type { BrowserWalletInfo } from '@/types/browserWallet';
 import { BROWSER_WALLETS, getInstalledWallets, isWalletInstalled } from '@/constants/wallets';
 // PSBT patching is now handled by ts-sdk wallet adapters (adapter.ts)
 // import { patchTapInternalKeys } from '@/lib/psbt-patching';

--- a/types/__tests__/browserWallet.compat.test.ts
+++ b/types/__tests__/browserWallet.compat.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Drift check: our local `BrowserWalletInfo` / `WalletAccount` /
+ * `PsbtSigningOptions` types must remain structurally compatible with the
+ * SDK's exports. If the SDK bumps and changes a shape, this test fails at
+ * compile time so we notice before a runtime crash.
+ *
+ * The test uses TypeScript's structural assignability via identity functions
+ * — no runtime assertions; `tsc --noEmit` either accepts it or doesn't.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type {
+  BrowserWalletInfo,
+  WalletAccount,
+  PsbtSigningOptions,
+} from '@/types/browserWallet';
+import type {
+  BrowserWalletInfo as SdkBrowserWalletInfo,
+  WalletAccount as SdkWalletAccount,
+  PsbtSigningOptions as SdkPsbtSigningOptions,
+} from '@alkanes/ts-sdk';
+
+function assertSdkCompat<SdkT, LocalT extends SdkT>(_x: LocalT): void {
+  // No-op at runtime. The type parameter constraint is what enforces
+  // LocalT is assignable to SdkT (and vice versa via the flipped call).
+}
+
+describe('browserWallet type compat with @alkanes/ts-sdk', () => {
+  it('BrowserWalletInfo is structurally compatible in both directions', () => {
+    const local: BrowserWalletInfo = {
+      id: 'unisat',
+      name: 'Unisat Wallet',
+      icon: 'data:image/png;base64,...',
+      website: 'https://unisat.io',
+      injectionKey: 'unisat',
+      supportsPsbt: true,
+      supportsTaproot: true,
+      supportsOrdinals: true,
+      mobileSupport: false,
+    };
+    assertSdkCompat<SdkBrowserWalletInfo, BrowserWalletInfo>(local);
+
+    const fromSdk: SdkBrowserWalletInfo = local;
+    assertSdkCompat<BrowserWalletInfo, SdkBrowserWalletInfo>(fromSdk);
+
+    expect(local.id).toBe('unisat');
+  });
+
+  it('WalletAccount is structurally compatible', () => {
+    const local: WalletAccount = {
+      address: 'bc1p...',
+      publicKey: '02...',
+      paymentAddress: 'bc1q...',
+      paymentPublicKey: '03...',
+    };
+    assertSdkCompat<SdkWalletAccount, WalletAccount>(local);
+
+    const fromSdk: SdkWalletAccount = local;
+    assertSdkCompat<WalletAccount, SdkWalletAccount>(fromSdk);
+
+    expect(local.address).toBe('bc1p...');
+  });
+
+  it('PsbtSigningOptions is structurally compatible', () => {
+    const local: PsbtSigningOptions = {
+      autoFinalized: true,
+      toSignInputs: [{ index: 0, address: 'bc1p...' }],
+    };
+    assertSdkCompat<SdkPsbtSigningOptions, PsbtSigningOptions>(local);
+
+    const fromSdk: SdkPsbtSigningOptions = local;
+    assertSdkCompat<PsbtSigningOptions, SdkPsbtSigningOptions>(fromSdk);
+
+    expect(local.autoFinalized).toBe(true);
+  });
+});

--- a/types/browserWallet.ts
+++ b/types/browserWallet.ts
@@ -1,0 +1,46 @@
+/**
+ * Browser wallet types used across subfrost-app.
+ *
+ * Duplicated from `@alkanes/ts-sdk` rather than re-exported so that
+ * callers can import types without traversing the SDK barrel. The
+ * shape must match the SDK's `BrowserWalletInfo` / `WalletAccount` /
+ * `PsbtSigningOptions` exactly — we still mix SDK wallet entries
+ * (with base64 icons) into our ordered list in `constants/wallets.ts`.
+ *
+ * If the SDK's shape changes, update this file to match. There is a
+ * structural compatibility test in the test suite that will fail
+ * loudly if they drift.
+ */
+
+export interface BrowserWalletInfo {
+  id: string;
+  name: string;
+  icon: string;
+  website: string;
+  injectionKey: string;
+  supportsPsbt: boolean;
+  supportsTaproot: boolean;
+  supportsOrdinals: boolean;
+  mobileSupport: boolean;
+  deepLinkScheme?: string;
+}
+
+export interface WalletAccount {
+  address: string;
+  publicKey?: string;
+  addressType?: string;
+  /** Payment address for dual-address wallets (Xverse, Leather, Magic Eden) */
+  paymentAddress?: string;
+  /** Payment public key for dual-address wallets */
+  paymentPublicKey?: string;
+}
+
+export interface PsbtSigningOptions {
+  autoFinalized?: boolean;
+  toSignInputs?: Array<{
+    index: number;
+    address?: string;
+    sighashTypes?: number[];
+    disableTweakedPublicKey?: boolean;
+  }>;
+}


### PR DESCRIPTION
## Summary

Phase 6 — decouples type-only callers from the SDK barrel. Runtime behavior unchanged.

Stacked on #61.

## Changes

- **New** \`types/browserWallet.ts\` — local copies of \`BrowserWalletInfo\`, \`WalletAccount\`, \`PsbtSigningOptions\`
- **New** \`types/__tests__/browserWallet.compat.test.ts\` — drift check: types must stay structurally compatible with the SDK exports. Fails at type-check time if they drift.
- \`constants/wallets.ts\` — type sourced from \`@/types/browserWallet\`; runtime \`BROWSER_WALLETS\` array still sourced from SDK (~600 LOC of base64 icons — no point duplicating)
- \`context/WalletContext.tsx\` — type import only; the 2,452-LOC body stays intact per CLAUDE.md

## Why not fully inline BROWSER_WALLETS

The SDK array ships wallet icons as embedded base64. Inlining would bloat the repo by ~600 LOC of noise for zero functional benefit. When we need to drop the SDK entirely, the icons can be moved to \`public/assets/wallets/\` as individual files.

## Verification

- ✅ \`tsc --noEmit\`
- ✅ \`pnpm run test:unit\`: 336 / 11,573 — +1 file +3 tests vs Phase 5 (the new compat suite)
- ✅ Same 3 pre-existing \`.claude/worktrees/*\` failures
- ✅ WASM pin MD5 \`4b936b89a3a8c4500639e78de7934133\` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)