### PR TITLE
phase 7: route server-side lua + BTC price through rpc.ts

### DIFF
--- a/lib/alkanes/rpc.ts
+++ b/lib/alkanes/rpc.ts
@@ -282,6 +282,35 @@ export async function metashrewView(
 }
 
 // ============================================================================
+// Lua script evaluation
+// ============================================================================
+
+/**
+ * Execute a Lua script via the metashrew node's `lua_evalscript` JSON-RPC
+ * method. The server evaluates the script with the provided arguments and
+ * returns whatever the script returns.
+ *
+ * Used for balance-aggregation + candle-backfill scripts that are too
+ * expensive to run as protostone simulations. The script is hashed + cached
+ * server-side, so repeated calls with the same script are O(1) dispatch.
+ */
+export async function luaEvalScript<T = unknown>(
+  network: string,
+  script: string,
+  args: unknown[],
+  signal?: AbortSignal,
+): Promise<T> {
+  const argsJson = JSON.stringify(args);
+  const result = await jsonRpcCall<unknown>(
+    subfrostRpcUrl(network),
+    'lua_evalscript',
+    [script, argsJson],
+    signal,
+  );
+  return result as T;
+}
+
+// ============================================================================
 // AMM pool data — via api.alkanode.com/rpc (third-party)
 // ============================================================================
 

--- a/lib/pools/candle-fetcher.ts
+++ b/lib/pools/candle-fetcher.ts
@@ -5,7 +5,8 @@
  * lua_evalscript with metashrew_view. Uses alkanes-client for RPC calls.
  */
 
-import { getAlkanesClient, type PoolConfig, getPools, calculatePrice } from '@/lib/alkanes-client';
+import { type PoolConfig, getPools, calculatePrice } from '@/lib/alkanes-client';
+import { luaEvalScript, getHeight } from '@/lib/alkanes/rpc';
 
 // ============================================================================
 // Types
@@ -311,10 +312,14 @@ export async function fetchPoolDataPoints(
   }
 
   try {
-    const client = getAlkanesClient(network);
-    const luaResult = await client.executeLuaScript<LuaScriptResult>(
+    // luaEvalScript targets the server's `lua_evalscript` method directly.
+    // The SDK's `executeLuaScript` wraps this via WASM but does nothing extra
+    // at runtime except serialize args as JSON (we do that ourselves).
+    // Script hash caching happens server-side.
+    const luaResult = await luaEvalScript<LuaScriptResult>(
+      network || 'mainnet',
       POOL_CANDLES_LUA_SCRIPT,
-      [[pool.protobufPayload, startHeight.toString(), endHeight.toString(), interval.toString()]]
+      [[pool.protobufPayload, startHeight.toString(), endHeight.toString(), interval.toString()]],
     );
 
     if (luaResult?.error) {
@@ -340,8 +345,7 @@ export async function fetchPoolDataPoints(
  * @param network - Optional network name for network-specific client
  */
 export async function getCurrentHeight(network?: string): Promise<number> {
-  const client = getAlkanesClient(network);
-  return client.getCurrentHeight();
+  return getHeight(network || 'mainnet');
 }
 
 /**
@@ -610,10 +614,10 @@ export async function fetchDieselStats(network?: string): Promise<{
   height: number;
 }> {
   try {
-    const client = getAlkanesClient(network);
-    const luaResult = await client.executeLuaScript<StatsLuaResult>(
+    const luaResult = await luaEvalScript<StatsLuaResult>(
+      network || 'mainnet',
       STATS_LUA_SCRIPT,
-      [[]]
+      [[]],
     );
 
     return {

--- a/lib/pools/pool-service.ts
+++ b/lib/pools/pool-service.ts
@@ -15,6 +15,7 @@ import {
   calculatePrice as calcPrice,
   type PoolConfig,
 } from '@/lib/alkanes-client';
+import { getBitcoinPrice as rpcGetBitcoinPrice } from '@/lib/alkanes/rpc';
 import {
   fetchPoolDataPoints,
   fetchDieselStats,
@@ -170,11 +171,12 @@ export async function getBitcoinPrice(_network?: string): Promise<BitcoinPrice> 
     return cached;
   }
 
-  // Always use mainnet for BTC price - it's the same across all networks
-  const client = getAlkanesClient('mainnet');
-  const price = await client.getBitcoinPrice();
+  // Always use mainnet for BTC price - it's the same across all networks.
+  // rpc.getBitcoinPrice hits the /api/btc-price Next.js route (same upstream
+  // the SDK's dataApi.getBitcoinPrice reached, minus the WASM boundary).
+  const { usd } = await rpcGetBitcoinPrice();
   const result: BitcoinPrice = {
-    usd: price,
+    usd,
     timestamp: Date.now(),
   };
 
@@ -239,6 +241,11 @@ export async function getPoolReserves(poolKey: string, network?: string): Promis
     };
   }
 
+  // Kept on AlkanesClient path for totalSupply fidelity: rpc.getPoolReserves
+  // (via api.alkanode.com/rpc ammdata.get_pools) returns reserves but not
+  // totalSupply. Switching would regress LP-supply UIs. Alkanes-client has
+  // a multi-source cascade (dataApi.getReserves → /get-pool-details) that
+  // provides totalSupply — see Phase 7 notes for the deferred optimization.
   const client = getAlkanesClient(network);
   const reserves = await client.getPoolReserves(pool);
   if (!reserves) return null;


### PR DESCRIPTION
## Summary

Phase 7 — reduces \`AlkanesClient\` (and WASM) usage on the Node-side pool/candle service. Does NOT fully gut \`lib/alkanes-client.ts\` — that's blocked by \`getPoolReserves\` totalSupply.

Stacked on #62.

## Changes

### \`lib/alkanes/rpc.ts\`
- New export: \`luaEvalScript(network, script, args, signal?)\` — thin fetch wrapper around the server's \`lua_evalscript\` JSON-RPC method
- Server hashes + caches scripts; same caching behavior as the SDK's \`executeLuaScript\`

### \`lib/pools/pool-service.ts\`
- \`getCurrentBitcoinPrice\`: \`client.getBitcoinPrice()\` → \`rpc.getBitcoinPrice()\`

### \`lib/pools/candle-fetcher.ts\`
- \`fetchPoolDataPoints\`: \`client.executeLuaScript()\` → \`rpc.luaEvalScript()\`
- \`getCurrentHeight\`: \`client.getCurrentHeight()\` → \`rpc.getHeight()\`
- \`fetchDieselStats\`: \`client.executeLuaScript()\` → \`rpc.luaEvalScript()\`
- Dropped \`getAlkanesClient\` import (no longer needed)

## Deferred

Full \`AlkanesClient\` gutting waits on a verified \`totalSupply\` source. The alkanode endpoint (\`ammdata.get_pools\`) doesn't return it, and the SDK's \`getPoolReserves\` has a multi-source cascade that does. Swapping today would silently zero-out LP supply in every UI that reads it.

## Verification

- ✅ \`tsc --noEmit\`
- ✅ \`pnpm run test:unit\`: 336 / 11,573 — byte-identical to Phase 6 baseline
- ✅ Same 3 pre-existing \`.claude/worktrees/*\` failures
- ✅ WASM pin MD5 \`4b936b89a3a8c4500639e78de7934133\` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)