### PR TITLE
phase 9: fee-estimation shim + close the minimization series

### DIFF
--- a/app/wallet/components/SendModal.tsx
+++ b/app/wallet/components/SendModal.tsx
@@ -117,7 +117,7 @@ import TokenIcon from '@/app/components/TokenIcon';
 import { useFeeRate, FeeSelection } from '@/hooks/useFeeRate';
 import { usePools } from '@/hooks/usePools';
 import { useTranslation } from '@/hooks/useTranslation';
-import { computeSendFee, estimateSelectionFee, DUST_THRESHOLD } from '@alkanes/ts-sdk';
+import { computeSendFee, estimateSelectionFee, DUST_THRESHOLD } from '@/lib/wallet/feeEstimation';
 import * as bitcoin from 'bitcoinjs-lib';
 import * as ecc from '@bitcoinerlab/secp256k1';
 import { injectRedeemScripts } from '@/lib/psbt-patching';

--- a/app/wallet/components/__tests__/SendModal.btc.test.ts
+++ b/app/wallet/components/__tests__/SendModal.btc.test.ts
@@ -17,7 +17,7 @@ import * as ecc from '@bitcoinerlab/secp256k1';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getBitcoinNetwork } from '@/lib/alkanes/helpers';
-import { computeSendFee, estimateSelectionFee, DUST_THRESHOLD } from '@alkanes/ts-sdk';
+import { computeSendFee, estimateSelectionFee, DUST_THRESHOLD } from '@/lib/wallet/feeEstimation';
 
 // ---------- Setup ----------
 
@@ -136,9 +136,14 @@ describe('Source code analysis — SendModal.tsx', () => {
     expect(source).toMatch(/\.toLowerCase\(\)/);
   });
 
-  it('uses computeSendFee from SDK for fee calculation', () => {
+  it('uses computeSendFee from fee-estimation shim for fee calculation', () => {
     expect(source).toContain('computeSendFee');
-    expect(source).toContain("import { computeSendFee, estimateSelectionFee, DUST_THRESHOLD } from '@alkanes/ts-sdk'");
+    // Phase 9 of the ts-sdk minimization: the fee helpers now come from
+    // `@/lib/wallet/feeEstimation`, which re-exports from `@alkanes/ts-sdk`.
+    // If the import line changes again, update this assertion.
+    expect(source).toContain(
+      "import { computeSendFee, estimateSelectionFee, DUST_THRESHOLD } from '@/lib/wallet/feeEstimation'",
+    );
   });
 });
 

--- a/lib/wallet/feeEstimation.ts
+++ b/lib/wallet/feeEstimation.ts
@@ -1,0 +1,25 @@
+/**
+ * Fee estimation shim — re-exports from @alkanes/ts-sdk.
+ *
+ * Phase 9 of the ts-sdk minimization plan. Matches the pattern established
+ * in `lib/wallet/keystore.ts`: app imports go through a local module we
+ * control, implementation still comes from the trusted SDK until we have
+ * the bandwidth to inline + test it.
+ *
+ * ## Why a shim for these three helpers
+ *
+ * `computeSendFee`, `estimateSelectionFee`, and `DUST_THRESHOLD` are pure
+ * arithmetic — no crypto primitives, no network I/O. Inlining them is
+ * genuinely low-risk (unlike `keystore.ts`). But there's a test in
+ * `SendModal.btc.test.ts:141` that hard-asserts the import source string,
+ * so we need to move the test + the source import together. That's a
+ * Phase-10 cleanup, not a Phase-9 shim.
+ *
+ * ## Current call sites
+ *
+ * - `app/wallet/components/SendModal.tsx` — BTC send fee preview + dust guard
+ * - `app/wallet/components/__tests__/SendModal.btc.test.ts` — tests the
+ *   fee math; hard-asserts the SendModal's import string
+ */
+
+export { computeSendFee, estimateSelectionFee, DUST_THRESHOLD } from '@alkanes/ts-sdk';


### PR DESCRIPTION
## Summary

Phase 9 (final) — last direct \`@alkanes/ts-sdk\` import in app code that isn't the execute path now routes through a local shim. Closes the ts-sdk minimization series.

Stacked on #64.

## Changes

- **New** \`lib/wallet/feeEstimation.ts\` — re-exports \`computeSendFee\`, \`estimateSelectionFee\`, \`DUST_THRESHOLD\` (same shim pattern as \`lib/wallet/keystore.ts\`)
- \`app/wallet/components/SendModal.tsx\` — import path swap
- \`app/wallet/components/__tests__/SendModal.btc.test.ts\` — import path swap + updated the hard-assert that checked the SendModal source's import string

## Remaining direct SDK imports (documented, deferred)

After Phase 9 merges:

- \`lib/alkanes/buildAlkaneTransferPsbt.ts\` — \`ProtoStone\`, \`encodeRunestoneProtostone\` (pure-TS encoder; SDK package.json has no \`./protostone\` subpath export)
- \`lib/alkanes-client.ts\` — \`AlkanesProvider\` class (Node-side client; full gut blocked by \`getPoolReserves\` totalSupply, see PR #63 notes)
- \`constants/wallets.ts\` — \`BROWSER_WALLETS\` array (600 LOC of base64 icons — duplication is noise)
- \`context/WalletContext.tsx\` — runtime wallet + adapter code (CLAUDE.md forbids body refactor during this series)

Future work can tackle each of these individually. The series established the pattern: shim first (this PR + #61, #62), inline later when fixtures are in place.

## Verification

- ✅ \`tsc --noEmit\`
- ✅ \`pnpm vitest run app/wallet/components/__tests__/SendModal.btc.test.ts\`: 294 / 294
- ✅ \`pnpm run test:unit\`: 336 / 11,573 — byte-identical to Phase 8 baseline
- ✅ Same 3 pre-existing \`.claude/worktrees/*\` failures
- ✅ WASM pin MD5 \`4b936b89a3a8c4500639e78de7934133\` unchanged

## Series summary (PRs #56 → #64)

| PR | Phase | Scope |
|---|---|---|
| #56 | 0 | Dead code, bundle analyzer, WASM cache headers, optimizePackageImports |
| #57 | 1 | Additive \`lib/alkanes/rpc.ts\` thin-fetch layer + 19 tests |
| #58 | 2 | \`useAlkanesTokenPairs\` + BTC price → rpc.ts |
| #59 | 3 | \`utils/alkaneRpc.ts\` + frBTC premium → rpc.ts |
| #60 | 4 | Fujin N+1 parallelization + CandleChart lazy-load |
| #61 | 5 | Keystore shim at \`@/lib/wallet/keystore\` |
| #62 | 6 | Local \`BrowserWalletInfo\` type + drift-check test |
| #63 | 7 | Pool/candle server-side lua + BTC price via rpc.ts |
| #64 | 8 | Per-network WebProvider cache |
| #65 | 9 | Fee-estimation shim (this PR) |

Every PR in the series maintained **byte-identical test baseline** (335–336 files / 11,570–11,573 passing, same 3 pre-existing \`.claude/worktrees\` failures). WASM pin MD5 stable throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)