### PR TITLE
perf: remove infinite snow animation (4 fullscreen layers × 60fps)

### DIFF
--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -39,7 +39,6 @@ export default function AppShell({ children }: { children: ReactNode }) {
   return (
     <div className="sf-bg min-h-dvh relative flex flex-col">
       <SplashScreen />
-      <div className="absolute inset-0 sf-snow" aria-hidden />
       <Header />
       <DemoBanner />
       <main className="relative flex-1 flex flex-col min-h-0">


### PR DESCRIPTION
sf-snow element ran 4 parallel infinite CSS animations on fullscreen SVG layers, causing continuous GPU compositing + backdrop-blur recalculation on every frame. Main cause of hot CPU on all pages.