### PR TITLE
fix(unisat): route signing through signWithUnisat (autoFinalized:true)

### DIFF
--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -66,7 +66,7 @@ import { BROWSER_WALLETS, getInstalledWallets, isWalletInstalled } from '@/const
 // import { patchTapInternalKeys } from '@/lib/psbt-patching';
 
 // Import browser wallet signing utilities with robust reconnection handling
-import { signWithOyl, signWithXverse, detectWalletId, getOylCallCount, resetOylCallCount, patchTapInternalKeys } from '@/lib/wallet/browserWalletSigning';
+import { signWithOyl, signWithUnisat, signWithXverse, detectWalletId, getOylCallCount, resetOylCallCount, patchTapInternalKeys } from '@/lib/wallet/browserWalletSigning';
 
 // Connection-specific counter for OYL getAddresses() calls during initial connection
 // Helps identify if React StrictMode is causing duplicate modal triggers
@@ -1852,7 +1852,45 @@ export function WalletProvider({ children, network }: WalletProviderProps) {
         }
       }
 
-      // For other browser wallets (UniSat, OKX, etc.), use the SDK adapter directly
+      // For UniSat wallet, use signWithUnisat which calls signPsbts with
+      // `autoFinalized: true`. UniSat's `autoFinalized: false` mode is buggy for
+      // taproot inputs — it returns partial-sig fields that bitcoinjs-lib's
+      // `finalizeAllInputs()` can't reconcile, throwing "Cannot finalize taproot
+      // input #N. No tapleaf script signature provided." (bitcoinjs falls
+      // through to script-path finalization because key-path metadata is
+      // incomplete from UniSat's side).
+      //
+      // The previous fallback at the bottom of this function called the SDK
+      // adapter with `auto_finalized: false`, which forwarded that flag to
+      // UniSat → triggered the bug. Routing UniSat through `signWithUnisat`
+      // (which passes `autoFinalized: true`) makes UniSat return a fully
+      // finalized PSBT (with `finalScriptWitness` set on each input) that
+      // every mutation hook can use directly.
+      //
+      // Source: 2026-04-28 unwrap regression with UniSat. Trace showed
+      // "[WalletContext] unisat signing succeeded (988 hex chars)" hitting
+      // the generic adapter path on line ~1860 instead of the UniSat-specific
+      // helper. Adding this branch routes UniSat through the right helper.
+      if (detectedWallet === 'unisat') {
+        try {
+          const unisatAddress = browserWalletAddresses?.taproot?.address || browserWallet?.address;
+          if (!unisatAddress) {
+            throw new Error('UniSat address not found');
+          }
+          console.log(`[WalletContext] UniSat: Using signWithUnisat (${psbt.inputCount} inputs, address=${unisatAddress})`);
+          const result = await signWithUnisat(psbt, unisatAddress);
+          console.log(`[WalletContext] UniSat: signing succeeded (finalized: ${result.isFinalized})`);
+          return result.signedPsbtBase64;
+        } catch (e: any) {
+          console.error(`[WalletContext] UniSat signing failed:`, e?.message || e);
+          throw new Error(`UniSat signing failed: ${e?.message || e}`);
+        }
+      }
+
+      // For other browser wallets (OKX, Leather, Phantom, etc.), use the SDK
+      // adapter directly. UniSat is handled above and avoids this path because
+      // `auto_finalized: false` is broken for UniSat taproot inputs (see comment
+      // on the UniSat branch).
       // IMPORTANT: Use the PATCHED psbt (with corrected tapInternalKey), not the original psbtBase64
       const patchedPsbtHex = psbt.toHex();
 
@@ -1982,6 +2020,33 @@ export function WalletProvider({ children, network }: WalletProviderProps) {
         } catch (e: any) {
           console.error(`[WalletContext] OYL (segwit) signing failed:`, e?.message || e);
           throw new Error(`OYL signing failed: ${e?.message || e}`);
+        }
+      }
+
+      // For UniSat, route through signWithUnisat for the same reason as the
+      // taproot path: the SDK adapter's `auto_finalized: false` mode produces
+      // PSBTs that bitcoinjs-lib's finalizer can't reconcile. signWithUnisat
+      // uses `autoFinalized: true` and returns finalized PSBTs.
+      if (detectWalletId(browserWallet) === 'unisat') {
+        try {
+          const bitcoin = await import('bitcoinjs-lib');
+          const btcNetwork = network === 'mainnet' ? bitcoin.networks.bitcoin
+            : network === 'signet' || network === 'testnet' ? bitcoin.networks.testnet
+            : bitcoin.networks.regtest;
+          const psbt = bitcoin.Psbt.fromBase64(psbtBase64, { network: btcNetwork });
+          const unisatAddress = browserWalletAddresses?.nativeSegwit?.address
+            || browserWalletAddresses?.taproot?.address
+            || browserWallet?.address;
+          if (!unisatAddress) {
+            throw new Error('UniSat address not found');
+          }
+          console.log(`[WalletContext] UniSat (segwit): Using signWithUnisat (${psbt.inputCount} inputs, address=${unisatAddress})`);
+          const result = await signWithUnisat(psbt, unisatAddress);
+          console.log(`[WalletContext] UniSat (segwit): signing succeeded (finalized: ${result.isFinalized})`);
+          return result.signedPsbtBase64;
+        } catch (e: any) {
+          console.error(`[WalletContext] UniSat (segwit) signing failed:`, e?.message || e);
+          throw new Error(`UniSat signing failed: ${e?.message || e}`);
         }
       }
 

--- a/hooks/useUnwrapMutation.ts
+++ b/hooks/useUnwrapMutation.ts
@@ -251,9 +251,21 @@ export function useUnwrapMutation() {
           signedPsbtBase64 = await signTaprootPsbt(signedPsbtBase64);
         }
 
-        // Finalize and extract transaction
+        // Finalize and extract transaction. Some wallets (UniSat with
+        // autoFinalized: true) return PSBTs that are already finalized —
+        // calling finalizeAllInputs() on those is at best wasteful and at
+        // worst throws because there's nothing left to finalize. Match the
+        // pattern used by useSwapMutation / useWrapMutation: only finalize
+        // if no input has finalScriptWitness or finalScriptSig set.
         const signedPsbt = bitcoin.Psbt.fromBase64(signedPsbtBase64, { network: btcNetwork });
-        signedPsbt.finalizeAllInputs();
+        const alreadyFinalized = signedPsbt.data.inputs.every(
+          input => input.finalScriptWitness || input.finalScriptSig,
+        );
+        if (alreadyFinalized) {
+          console.log('[useUnwrapMutation] PSBT already finalized by wallet, skipping finalizeAllInputs');
+        } else {
+          signedPsbt.finalizeAllInputs();
+        }
 
         const tx = signedPsbt.extractTransaction();
         const txHex = tx.toHex();


### PR DESCRIPTION
## Summary
- UniSat unwraps and other taproot-input mutations failed at finalization with `Cannot finalize taproot input #0. No tapleaf script signature provided.`
- Root cause: `WalletContext.signTaprootPsbt` / `signSegwitPsbt` had branches for OYL and Xverse, but UniSat fell through to the generic SDK adapter which calls `walletAdapter.signPsbt(hex, { auto_finalized: false })`. UniSat's `autoFinalized:false` mode is buggy for taproot inputs — partial sigs land in fields bitcoinjs-lib's finalizer can't reconcile.
- Fix: add an explicit UniSat branch in both signing methods that routes through `signWithUnisat` (which uses `autoFinalized:true`); guard `finalizeAllInputs()` in `useUnwrapMutation` with the `alreadyFinalized` check that swap/wrap already use.

## Why wraps worked but unwraps didn't
Wraps consume segwit inputs where the SDK adapter's `auto_finalized:false` mode produces PSBTs bitcoinjs can finalize via partial sigs. Unwraps consume P2TR inputs — same code path falls through to script-path finalization in bitcoinjs and bails because key-path metadata is incomplete from UniSat's side.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Mainnet unwrap signed and broadcast: tx `90f857372f1adf752547d4abace02adc772053f225cf7161cc98b855d8f49bae`
  - Two P2TR inputs, both with valid taproot key-path schnorr witnesses
  - Three P2TR outputs to user + 1 OP_RETURN protostone
  - 858 sat fee, ~2.24 sat/vB (requested 3 sat/vB)
- [ ] Verify wrap still works on UniSat after this change (now also routes through `signWithUnisat`)
- [ ] Verify swap-alkane still works on UniSat (same path)
- [ ] Verify OYL / Xverse paths unchanged (their explicit branches are above the new UniSat branch)

## Files changed
- `context/WalletContext.tsx` — import `signWithUnisat`; add UniSat branch in both signing methods
- `hooks/useUnwrapMutation.ts` — `alreadyFinalized` guard around `finalizeAllInputs()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)