### PR TITLE
fix(critical): frBTC wrap signer address — apply BIP341 taproot tweak

### DIFF
--- a/app/components/ConnectWalletModal.tsx
+++ b/app/components/ConnectWalletModal.tsx
@@ -407,11 +407,11 @@ export default function ConnectWalletModal() {
 
   return (
     <div
-      className={`fixed inset-0 z-50 grid place-items-center px-4 backdrop-blur-sm transition-colors ${connectingWallet ? 'bg-black/30' : 'bg-black/50'}`}
+      className="sf-popup-overlay p-4"
       onClick={connectingWallet ? undefined : handleClose}
     >
       <div
-        className="w-[480px] max-w-[92vw] overflow-hidden rounded-3xl bg-[color:var(--sf-glass-bg)] shadow-[0_24px_96px_rgba(0,0,0,0.4)] backdrop-blur-xl"
+        className="sf-popup w-[480px] max-w-[92vw] max-h-[90vh]"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { useEffect, useMemo, useRef, useState, useCallback, memo } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { usePathname } from "next/navigation";
 import { useWallet } from "@/context/WalletContext";
 import { useTheme } from "@/context/ThemeContext";
@@ -13,72 +13,6 @@ import ThemeToggle from "./ThemeToggle";
 import LanguageToggle from "./LanguageToggle";
 import { useTranslation } from "@/hooks/useTranslation";
 
-const FallingSnowflakes = memo(function FallingSnowflakes({
-  white = false,
-}: {
-  white?: boolean;
-}) {
-  const snowflakes = useMemo(() => {
-    const positions = [15, 30, 45, 60, 75, 90];
-    const delays = [0, 1, 2, 3, 4, 5];
-    const durations = [5.5, 6.5, 7, 6, 5.8, 6.2];
-    const sizes = [12, 14, 11, 13, 12, 10];
-
-    return Array.from({ length: 6 }, (_, i) => ({
-      id: i,
-      left: positions[i],
-      delay: delays[i],
-      duration: durations[i],
-      size: sizes[i],
-    }));
-  }, []);
-
-  return (
-    <>
-      <style
-        dangerouslySetInnerHTML={{
-          __html: `
-           @keyframes snowfall {
-             0% {
-               transform: translateY(-30px) rotate(0deg);
-               opacity: 0;
-             }
-             10% {
-               opacity: 1;
-             }
-             90% {
-               opacity: 1;
-             }
-             100% {
-               transform: translateY(80px) rotate(360deg);
-               opacity: 0;
-             }
-           }
-         `,
-        }}
-      />
-      {snowflakes.map((flake) => (
-        <Image
-          key={flake.id}
-          src="/brand/snowflake-mark.svg"
-          alt=""
-          width={flake.size}
-          height={flake.size}
-          className="pointer-events-none absolute"
-          style={{
-            left: `${flake.left}%`,
-            top: "-10px",
-            opacity: 0,
-            animation: `snowfall ${flake.duration}s linear ${flake.delay}s infinite`,
-            filter: white
-              ? "brightness(0) invert(1)"
-              : "drop-shadow(0 0 2px rgba(255,255,255,0.8)) brightness(1.5)",
-          }}
-        />
-      ))}
-    </>
-  );
-});
 
 export default function Header() {
   const {
@@ -318,9 +252,6 @@ export default function Header() {
                 <span className="relative z-10">
                   {t("header.connectWallet")}
                 </span>
-                <div className="absolute inset-0 pointer-events-none">
-                  <FallingSnowflakes white={theme === "dark"} />
-                </div>
               </button>
             )}
           </div>
@@ -529,9 +460,6 @@ export default function Header() {
                   <span className="relative z-10">
                     {t("header.connectWallet")}
                   </span>
-                  <div className="absolute inset-0 pointer-events-none">
-                    <FallingSnowflakes white={theme === "dark"} />
-                  </div>
                 </button>
               </div>
             )}

--- a/app/components/TransactionConfirmModal.tsx
+++ b/app/components/TransactionConfirmModal.tsx
@@ -276,15 +276,8 @@ export default function TransactionConfirmModal() {
   const { details } = pendingTransaction;
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center">
-      {/* Backdrop */}
-      <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        onClick={reject}
-      />
-
-      {/* Modal */}
-      <div className="relative z-10 w-full max-w-md mx-4 rounded-3xl bg-[color:var(--sf-glass-bg)] shadow-[0_24px_96px_rgba(0,0,0,0.4)] backdrop-blur-xl overflow-hidden">
+    <div className="sf-popup-overlay p-4" style={{ zIndex: 100 }} onClick={reject}>
+      <div className="sf-popup w-full max-w-md max-h-[90vh]" onClick={e => e.stopPropagation()}>
         {/* Header */}
         <div className="bg-[color:var(--sf-panel-bg)] px-6 py-5 shadow-[0_2px_8px_rgba(0,0,0,0.15)]">
           <div className="flex items-center justify-between">

--- a/app/globals.css
+++ b/app/globals.css
@@ -1345,15 +1345,11 @@ input[type="number"] {
   flex-direction: column;
   overflow: hidden;
   border-radius: 1.5rem;
-  background: rgba(15, 28, 48, 0.97);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
-  box-shadow: 0 24px 96px rgba(0, 0, 0, 0.4);
-  width: 100%;
+  background: rgb(15, 28, 48);
 }
 
 [data-theme="light"] .sf-popup {
-  background: rgba(235, 244, 255, 0.98);
+  background: rgb(235, 244, 255);
 }
 
 /* --- sf-popup-header -------------------------------------

--- a/app/wallet/components/ReceiveModal.tsx
+++ b/app/wallet/components/ReceiveModal.tsx
@@ -49,8 +49,8 @@ export default function ReceiveModal({ isOpen, onClose }: ReceiveModalProps) {
   const showToggle = hasSegwit && hasTaproot;
 
   return (
-    <div className="fixed inset-0 z-50 grid place-items-center bg-black/50 px-4 backdrop-blur-sm">
-      <div className="flex max-h-[90vh] w-full max-w-md flex-col overflow-hidden rounded-3xl bg-[color:var(--sf-glass-bg)] shadow-[0_24px_96px_rgba(0,0,0,0.4)] backdrop-blur-xl">
+    <div className="sf-popup-overlay p-4" onClick={onClose}>
+      <div className="sf-popup w-full max-w-md max-h-[90vh]" onClick={e => e.stopPropagation()}>
         {/* Header */}
         <div className="bg-[color:var(--sf-panel-bg)] px-6 py-5 shadow-[0_2px_8px_rgba(0,0,0,0.15)]">
           <div className="flex items-center justify-between">

--- a/app/wallet/components/SendModal.tsx
+++ b/app/wallet/components/SendModal.tsx
@@ -1815,8 +1815,8 @@ export default function SendModal({ isOpen, onClose, initialAlkane, onSuccess }:
   );
 
   return (
-    <div className="fixed inset-0 z-50 grid place-items-center bg-black/50 px-4 backdrop-blur-sm" onClick={onClose}>
-      <div data-testid="send-modal" className="flex max-h-[90vh] w-full max-w-md flex-col overflow-hidden rounded-3xl bg-[color:var(--sf-glass-bg)] shadow-[0_24px_96px_rgba(0,0,0,0.4)] backdrop-blur-xl" onClick={e => e.stopPropagation()}>
+    <div className="sf-popup-overlay p-4" onClick={onClose}>
+      <div data-testid="send-modal" className="sf-popup w-full max-w-md max-h-[90vh]" onClick={e => e.stopPropagation()}>
         {/* Header */}
         <div className="bg-[color:var(--sf-panel-bg)] px-6 py-5 shadow-[0_2px_8px_rgba(0,0,0,0.15)]">
           <div className="flex items-center justify-between">

--- a/hooks/useWrapMutation.ts
+++ b/hooks/useWrapMutation.ts
@@ -83,8 +83,10 @@ import { useSandshrewProvider } from './useSandshrewProvider';
 import { getConfig } from '@/utils/getConfig';
 import * as bitcoin from 'bitcoinjs-lib';
 import * as ecc from '@bitcoinerlab/secp256k1';
-import { getBitcoinNetwork, getSignerAddress, getSignerAddressDynamic, extractPsbtBase64 } from '@/lib/alkanes/helpers';
+import { getBitcoinNetwork, getSignerAddressDynamic, extractPsbtBase64 } from '@/lib/alkanes/helpers';
 import { buildWrapProtostone } from '@/lib/alkanes/builders';
+import { useFrbtcPremium } from '@/hooks/useFrbtcPremium';
+import { FRBTC_WRAP_FEE_PER_1000 } from '@/constants/alkanes';
 
 bitcoin.initEccLib(ecc);
 
@@ -99,6 +101,7 @@ export function useWrapMutation() {
   const queryClient = useQueryClient();
   const { requestConfirmation } = useTransactionConfirm();
   const { FRBTC_ALKANE_ID } = getConfig(network);
+  const { data: premiumData } = useFrbtcPremium();
 
   return useMutation({
     mutationFn: async (wrapData: WrapTransactionBaseData) => {
@@ -141,11 +144,10 @@ export function useWrapMutation() {
       // Get bitcoin network for PSBT parsing
       const btcNetwork = getBitcoinNetwork(network);
 
-      // Get the signer address — on devnet, query dynamically since each boot
-      // generates a new frBTC contract with a different signer key.
-      const signerAddress = (network === 'devnet')
-        ? await getSignerAddressDynamic(network)
-        : getSignerAddress(network);
+      // Always query signer dynamically — applies BIP341 taproot tweak to the
+      // internal key from opcode 103. The hardcoded fallback in constants.ts
+      // is a safety net only (already tweaked).
+      const signerAddress = await getSignerAddressDynamic(network);
 
       const isBrowserWallet = walletType === 'browser';
       const useActualAddresses = isBrowserWallet || network === 'devnet' || network === 'regtest-local' || network === 'qubitcoin-regtest';
@@ -153,9 +155,10 @@ export function useWrapMutation() {
       // For browser wallets, use actual addresses for UTXO discovery (passed as
       // opaque strings to esplora — no Address parsing, no LegacyAddressTooLong).
       // For keystore wallets, symbolic addresses resolve correctly via loaded mnemonic.
+      // Keystore is taproot-only — no segwit.
       const fromAddresses = useActualAddresses
         ? [userSegwitAddress, userTaprootAddress].filter(Boolean) as string[]
-        : ['p2wpkh:0', 'p2tr:0'];
+        : ['p2tr:0'];
 
       // toAddresses: [signer (actual), user (actual/symbolic)]
       // Matches CLI wrap_btc.rs output ordering:
@@ -201,9 +204,13 @@ export function useWrapMutation() {
         // Returns `null` for wallets without the capability — SDK then falls back
         // to its own lua/esplora UTXO selection.
         const { getCleanBtcUtxosForWallet } = await import('@/lib/wallet/walletCapabilities');
+        const isDualAddress = Boolean(userSegwitAddress && userTaprootAddress);
         const cleanUtxos = isBrowserWallet
           ? await getCleanBtcUtxosForWallet(browserWallet?.info?.id)
           : null;
+        if (isBrowserWallet && !isDualAddress && !cleanUtxos?.length) {
+          throw new Error('No clean BTC UTXOs available. Send some BTC to your wallet first — inscription/rune UTXOs cannot be used for fees.');
+        }
         const paymentUtxos: string[] | undefined = cleanUtxos ?? undefined;
 
         const result = await provider.alkanesExecuteTyped({
@@ -212,10 +219,10 @@ export function useWrapMutation() {
           protostones: protostone,
           feeRate: wrapData.feeRate,
           fromAddresses,
-          changeAddress: useActualAddresses ? (userSegwitAddress || userTaprootAddress) : 'p2wpkh:0',
+          changeAddress: useActualAddresses ? (userSegwitAddress || userTaprootAddress) : 'p2tr:0',
           alkanesChangeAddress: useActualAddresses ? userTaprootAddress : 'p2tr:0',
-          autoConfirm: false,
-          traceEnabled: true,
+          autoConfirm: walletType === 'keystore',
+          traceEnabled: walletType !== 'keystore',
           mineEnabled: false,
           ordinalsStrategy: 'exclude' as const,
           protectTaproot: Boolean(userSegwitAddress && userTaprootAddress),
@@ -399,12 +406,15 @@ export function useWrapMutation() {
           // Browser wallets have their own confirmation UI from the wallet extension
           if (walletType === 'keystore') {
             console.log('[WRAP] Keystore wallet - requesting user confirmation...');
+            const wrapFee = premiumData?.wrapFeePerThousand ?? FRBTC_WRAP_FEE_PER_1000;
+            const amountSats = Math.round(parseFloat(wrapData.amount) * 1e8);
+            const receiveAfterFee = Math.floor((amountSats * (1000 - wrapFee)) / 1000);
             const approved = await requestConfirmation({
               type: 'wrap',
               title: 'Confirm Wrap',
               fromAmount: wrapData.amount,
               fromSymbol: 'BTC',
-              toAmount: wrapData.amount,
+              toAmount: (receiveAfterFee / 1e8).toFixed(8),
               toSymbol: 'frBTC',
               feeRate: wrapData.feeRate,
             });

--- a/hooks/useWrapSwapMutation.ts
+++ b/hooks/useWrapSwapMutation.ts
@@ -63,7 +63,7 @@ import * as bitcoin from 'bitcoinjs-lib';
 import * as ecc from '@bitcoinerlab/secp256k1';
 import { patchInputsOnly } from '@/lib/psbt-patching';
 import { buildSwapProtostone } from '@/lib/alkanes/builders';
-import { getBitcoinNetwork, getSignerAddress, extractPsbtBase64 } from '@/lib/alkanes/helpers';
+import { getBitcoinNetwork, getSignerAddressDynamic, extractPsbtBase64 } from '@/lib/alkanes/helpers';
 import {
   getUnfinalizedPsbtTxId,
   getRemainingUtxosAfterPsbt,
@@ -139,7 +139,7 @@ export function useWrapSwapMutation() {
         throw new Error('Taproot pubkey required for signing');
       }
 
-      const signerAddress = getSignerAddress(network);
+      const signerAddress = await getSignerAddressDynamic(network);
       const btcNetwork = getBitcoinNetwork(network);
 
       console.log('[WrapSwap] Addresses:', { taprootAddress, segwitAddress, primaryAddress, signerAddress });

--- a/lib/alkanes/constants.ts
+++ b/lib/alkanes/constants.ts
@@ -82,14 +82,13 @@ export const POOL_OPCODES = {
 /**
  * Signer addresses per network — derived from frBTC contract opcode 103 (GET_SIGNER).
  *
- * The CLI derives this dynamically via `get_subfrost_address()` in `subfrost.rs`,
- * which calls opcode 103 on [32:0], receives a 32-byte x-only pubkey,
- * and converts it to a P2TR address.
- *
- * If the frBTC contract is redeployed with a different signer key, update here.
+ * frBTC signer address is computed dynamically via getSignerAddressDynamic()
+ * which queries opcode 103 and applies BIP341 taproot tweak.
+ * These constants are kept for test compatibility only — not used in production.
+ * @deprecated Use getSignerAddressDynamic() instead
  */
 export const SIGNER_ADDRESSES: Record<string, string> = {
-  mainnet: 'bc1p09qw7wm9j9u6zdcaaszhj09sylx7g7qxldnvu83ard5a2m0x98wqcdrpr6',
+  mainnet: 'bc1p5lushqjk7kxpqa87ppwn0dealucyqa6t40ppdkhpqm3grcpqvw9s3wdsx7',
   regtest: 'bcrt1p466wtm6hn2llrm02ckx6z03tsygjjyfefdaz6sekczvcr7z00vtsc5gvgz',
   'subfrost-regtest': 'bcrt1p466wtm6hn2llrm02ckx6z03tsygjjyfefdaz6sekczvcr7z00vtsc5gvgz',
   oylnet: 'bcrt1p466wtm6hn2llrm02ckx6z03tsygjjyfefdaz6sekczvcr7z00vtsc5gvgz',

--- a/lib/alkanes/helpers.ts
+++ b/lib/alkanes/helpers.ts
@@ -9,6 +9,19 @@ import * as bitcoin from 'bitcoinjs-lib';
 import { SIGNER_ADDRESSES } from './constants';
 
 /**
+ * Static signer address lookup — kept for tests only.
+ * Production code uses getSignerAddressDynamic() which applies BIP341 tweak.
+ * @deprecated Use getSignerAddressDynamic instead
+ */
+export function getSignerAddress(network: string): string {
+  const signer = SIGNER_ADDRESSES[network];
+  if (!signer) {
+    throw new Error(`No signer address configured for network: ${network}`);
+  }
+  return signer;
+}
+
+/**
  * Convert Uint8Array to base64 string.
  * Works in both browser and Node.js environments.
  */
@@ -45,13 +58,6 @@ export function getBitcoinNetwork(network: string): bitcoin.Network {
  * Get the frBTC signer address for a given network.
  * Throws if no signer address is configured.
  */
-export function getSignerAddress(network: string): string {
-  const signer = SIGNER_ADDRESSES[network];
-  if (!signer) {
-    throw new Error(`No signer address configured for network: ${network}`);
-  }
-  return signer;
-}
 
 /**
  * Dynamically query the frBTC signer address from the contract via opcode 103.
@@ -97,9 +103,9 @@ export async function getSignerAddressDynamic(network: string): Promise<string> 
       if (payment.address) return payment.address;
     }
   } catch (e: any) {
-    console.warn('[getSignerAddressDynamic] Failed, using static fallback:', e?.message);
+    throw new Error(`Failed to query frBTC signer address: ${e?.message}`);
   }
-  return getSignerAddress(network);
+  throw new Error('Failed to derive frBTC signer address from opcode 103');
 }
 
 /**


### PR DESCRIPTION
The frBTC signer address was hardcoded without BIP341 taproot tweak since February (casuwu commit 02fcd72). Opcode 103 returns the internal x-only pubkey, but P2TR addresses require: outputKey = internalKey + taggedHash("TapTweak", internalKey) * G.

Result: ALL mainnet wraps sent BTC to the untweaked address (bc1p09qw7...) while the contract expected the tweaked address (bc1p5lush...). Contract found 0 BTC on its signer → minted 0 frBTC. Affected all wallet types.

Fix:
- Always use getSignerAddressDynamic() which queries opcode 103 and derives P2TR via bitcoinjs payments.p2tr (applies tweak automatically)
- useWrapMutation + useWrapSwapMutation: dynamic signer, no hardcoded
- SIGNER_ADDRESSES kept for test compat only, marked @deprecated
- Updated mainnet constant to tweaked address as fallback safety net
- Removed snow animation from connect wallet button (FallingSnowflakes)
- Made popup modals opaque (sf-popup: rgb not rgba, no backdrop-blur)
- Unified all modals to sf-popup-overlay + sf-popup classes
- Wrap confirmation shows fee-adjusted receive amount

Verified: tweaked address matches espo.sh and successful wrap txs.