### PR TITLE
fix(unwrap): pass dustVout + amount in cellpack, add signer P2TR dust output

### DIFF
--- a/__tests__/sdk/e2e-swap-flow.test.ts
+++ b/__tests__/sdk/e2e-swap-flow.test.ts
@@ -162,7 +162,13 @@ function buildSwapProtostone(params: {
  *
  * p0: Edict   [sell_block:sell_tx:amount:p1]:v0:v0
  * p1: Swap    [factory_block,factory_tx,13,2,sell_block,sell_tx,frbtc_block,frbtc_tx,amount,minFrbtc,deadline]:p2:v0
- * p2: Unwrap  [frbtc_block,frbtc_tx,78]:v0:v0
+ * p2: Unwrap  [frbtc_block,frbtc_tx,78,dustVout,minFrbtc]:v0:v0
+ *
+ * The unwrap cellpack MUST carry (vout, amount). Pre-2026-04-29 this builder
+ * omitted them and the contract reverted with "Cannot burn less than dust
+ * amount" — see hooks/useUnwrapMutation.ts header for the full bug story.
+ * Caller MUST place the FROST signer's tweaked P2TR script at output index
+ * `dustVout`.
  */
 function buildSwapUnwrapProtostone(params: {
   sellTokenId: string;
@@ -171,6 +177,8 @@ function buildSwapUnwrapProtostone(params: {
   factoryId: string;
   minFrbtcOutput: string;
   deadline: string;
+  /** Index of the P2TR signer dust output in this tx. */
+  dustVout: number;
 }): string {
   const [sellBlock, sellTx] = params.sellTokenId.split(':');
   const [frbtcBlock, frbtcTx] = params.frbtcId.split(':');
@@ -186,7 +194,9 @@ function buildSwapUnwrapProtostone(params: {
   ].join(',');
   const p1 = `[${swapCellpack}]:p2:v0`;
 
-  const unwrapCellpack = [frbtcBlock, frbtcTx, 78].join(',');
+  // Cellpack: [block, tx, 78, dustVout, amount]. amount=minFrbtcOutput acts as
+  // the ceiling; the contract `min()`s against actual frBTC routed in from p1.
+  const unwrapCellpack = [frbtcBlock, frbtcTx, 78, params.dustVout, params.minFrbtcOutput].join(',');
   const p2 = `[${unwrapCellpack}]:v0:v0`;
 
   return `${p0},${p1},${p2}`;
@@ -632,6 +642,11 @@ describe.runIf(INTEGRATION)('E2E Swap Flow (integration)', () => {
       const minFrbtcOutput = '1';
       const deadline = '999999999';
 
+      // 3-output unwrap layout (matches useUnwrapMutation/useSwapUnwrapMutation):
+      //   v0: alkanes refund (walletAddress, taproot)
+      //   v1: BTC recipient (walletAddress)  ← could split to segwit if desired
+      //   v2: signer P2TR dust  ← dustVout = 2
+      const SIGNER_DUST_VOUT = 2;
       const protostone = buildSwapUnwrapProtostone({
         sellTokenId: DIESEL_ID,
         sellAmount,
@@ -639,10 +654,11 @@ describe.runIf(INTEGRATION)('E2E Swap Flow (integration)', () => {
         factoryId: FACTORY_ID,
         minFrbtcOutput,
         deadline,
+        dustVout: SIGNER_DUST_VOUT,
       });
 
       const inputRequirements = `2:0:${sellAmount}`;
-      const toAddresses = [walletAddress, SIGNER_ADDRESS];
+      const toAddresses = [walletAddress, walletAddress, SIGNER_ADDRESS];
 
       console.log('[SwapUnwrap] protostone:', protostone);
       console.log('[SwapUnwrap] inputRequirements:', inputRequirements);

--- a/__tests__/tier1/unwrap-frbtc.test.ts
+++ b/__tests__/tier1/unwrap-frbtc.test.ts
@@ -83,8 +83,16 @@ describe.runIf(INTEGRATION)('Tier 1: Unwrap frBTC -> BTC', () => {
 
     expect(frbtcBefore).toBeGreaterThanOrEqual(BigInt(unwrapAmount));
 
-    // Build unwrap transaction
-    const protostones = buildUnwrapProtostone({ frbtcId: REGTEST.FRBTC_ID });
+    // Build unwrap transaction.
+    // 3-output canonical layout: [alkanes-refund (taproot), btc-recipient
+    // (segwit), signer P2TR dust]. dustVout=2 indexes the signer dust output.
+    // Without this layout the contract reverts with "Cannot burn less than
+    // dust amount" (see hooks/useUnwrapMutation.ts header for the full story).
+    const protostones = buildUnwrapProtostone({
+      frbtcId: REGTEST.FRBTC_ID,
+      dustVout: 2,
+      amount: unwrapAmount,
+    });
     const inputRequirements = buildUnwrapInputRequirements({
       frbtcId: REGTEST.FRBTC_ID,
       amount: unwrapAmount,
@@ -96,7 +104,7 @@ describe.runIf(INTEGRATION)('Tier 1: Unwrap frBTC -> BTC', () => {
       feeRate: 2,
       // Put taproot first since frBTC UTXOs are there
       fromAddresses: [taprootAddress, segwitAddress],
-      toAddresses: [segwitAddress],
+      toAddresses: [taprootAddress, segwitAddress, REGTEST.FRBTC_SIGNER],
       changeAddress: segwitAddress,
       alkanesChangeAddress: taprootAddress,
     });

--- a/hooks/__tests__/mutations/calldata.test.ts
+++ b/hooks/__tests__/mutations/calldata.test.ts
@@ -335,31 +335,41 @@ describe('buildWrapProtostone', () => {
 describe('buildUnwrapProtostone', () => {
   const FRBTC_ID = '32:0';
 
+  // Cellpack format: [block, tx, 78, dustVout, amount]. Per fr-btc/contract.wit
+  // `unwrap(vout: u64, amount-requested: u64)`. The dustVout indexes into the
+  // tx outputs and MUST point at the FROST signer's tweaked P2TR script —
+  // see fr-btc/src/lib.rs:262-267 (`signer_script == tx.output[vout]...`).
   it('should build correct unwrap protostone with default pointers', () => {
     const protostone = buildUnwrapProtostone({
       frbtcId: FRBTC_ID,
+      dustVout: 2,
+      amount: '500000',
     });
 
-    // Shared builder defaults to v1:v1
-    expect(protostone).toBe('[32,0,78]:v1:v1');
+    // Defaults: pointer=v1 (BTC recipient), refund=v0 (alkanes refund).
+    expect(protostone).toBe('[32,0,78,2,500000]:v1:v0');
   });
 
   it('should build correct unwrap protostone with custom pointers', () => {
     const protostone = buildUnwrapProtostone({
       frbtcId: FRBTC_ID,
+      dustVout: 2,
+      amount: '500000',
       pointer: 'v1',
       refund: 'v2',
     });
 
-    expect(protostone).toBe('[32,0,78]:v1:v2');
+    expect(protostone).toBe('[32,0,78,2,500000]:v1:v2');
   });
 
   it('should use opcode 78 for unwrap', () => {
     const protostone = buildUnwrapProtostone({
       frbtcId: FRBTC_ID,
+      dustVout: 2,
+      amount: '500000',
     });
 
-    expect(protostone).toContain(',78]');
+    expect(protostone).toContain(',78,');
   });
 });
 
@@ -570,9 +580,13 @@ describe('Integration: Transaction Building', () => {
       const FRBTC_ID = '32:0';
       const UNWRAP_AMOUNT = '100000000'; // 1 frBTC
 
-      // Build protostone
+      // Build protostone — opcode 78 takes (vout, amount). dustVout=2 mirrors
+      // the canonical 3-output layout used by useUnwrapMutation:
+      //   v0=alkanes refund, v1=BTC recipient, v2=signer P2TR dust.
       const protostone = buildUnwrapProtostone({
         frbtcId: FRBTC_ID,
+        dustVout: 2,
+        amount: UNWRAP_AMOUNT,
       });
 
       // Build input requirements
@@ -580,7 +594,7 @@ describe('Integration: Transaction Building', () => {
         alkaneInputs: [{ alkaneId: FRBTC_ID, amount: UNWRAP_AMOUNT }],
       });
 
-      expect(protostone).toBe('[32,0,78]:v1:v1');
+      expect(protostone).toBe('[32,0,78,2,100000000]:v1:v0');
       expect(inputRequirements).toBe('32:0:100000000');
     });
   });

--- a/hooks/__tests__/mutations/wrap-mutation.test.ts
+++ b/hooks/__tests__/mutations/wrap-mutation.test.ts
@@ -216,22 +216,34 @@ describe('Browser wallet address handling in useWrapMutation', () => {
 // ---------------------------------------------------------------------------
 
 describe('Unwrap frBTC→BTC protostone', () => {
-  it('should use opcode 78', () => {
-    const result = buildUnwrapProtostone({ frbtcId: FRBTC_ID });
-    expect(result).toContain(`,${FRBTC_UNWRAP_OPCODE}]`);
+  // Cellpack now carries the contract args [block, tx, 78, dustVout, amount]
+  // — see useUnwrapMutation.ts header for the 2026-04-29 fix.
+  it('should use opcode 78 followed by the dustVout arg', () => {
+    const result = buildUnwrapProtostone({
+      frbtcId: FRBTC_ID,
+      dustVout: 2,
+      amount: '500000',
+    });
+    expect(result).toContain(`,${FRBTC_UNWRAP_OPCODE},2,`);
   });
 
-  it('should default pointer and refund to v1:v1', () => {
-    const result = buildUnwrapProtostone({ frbtcId: FRBTC_ID });
-    expect(result).toBe('[32,0,78]:v1:v1');
+  it('should default pointer to v1 (BTC recipient) and refund to v0 (alkanes)', () => {
+    const result = buildUnwrapProtostone({
+      frbtcId: FRBTC_ID,
+      dustVout: 2,
+      amount: '500000',
+    });
+    expect(result).toBe('[32,0,78,2,500000]:v1:v0');
   });
 
   it('should accept custom pointer and refund', () => {
     const result = buildUnwrapProtostone({
       frbtcId: FRBTC_ID,
+      dustVout: 2,
+      amount: '500000',
       pointer: 'v0',
       refund: 'v0',
     });
-    expect(result).toBe('[32,0,78]:v0:v0');
+    expect(result).toBe('[32,0,78,2,500000]:v0:v0');
   });
 });

--- a/hooks/useSwapUnwrapMutation.ts
+++ b/hooks/useSwapUnwrapMutation.ts
@@ -71,7 +71,7 @@ import * as bitcoin from 'bitcoinjs-lib';
 import * as ecc from '@bitcoinerlab/secp256k1';
 import { patchInputsOnly } from '@/lib/psbt-patching';
 import { buildSwapProtostone, buildSwapInputRequirements, buildUnwrapProtostone } from '@/lib/alkanes/builders';
-import { getBitcoinNetwork, extractPsbtBase64 } from '@/lib/alkanes/helpers';
+import { getBitcoinNetwork, extractPsbtBase64, getSignerAddressDynamic } from '@/lib/alkanes/helpers';
 import {
   getUnfinalizedPsbtTxId,
   getRemainingUtxosAfterPsbt,
@@ -329,20 +329,44 @@ export function useSwapUnwrapMutation() {
       // ========================================================================
       console.log('[SwapUnwrap] Building unwrap PSBT...');
 
-      // Build unwrap protostone
+      // ----------------------------------------------------------------------
+      // Resolve FROST signer's BIP341-tweaked P2TR address (always dynamic).
+      // The unwrap cellpack carries `[32, 0, 78, dustVout, amount]` and the
+      // contract requires `tx.output[dustVout].script_pubkey == signer_script`
+      // — that script is the TWEAKED P2TR. The hardcoded mainnet constant in
+      // SIGNER_ADDRESSES is the untweaked internal pubkey and would send dust
+      // to the wrong script. See useUnwrapMutation.ts header for the full
+      // bug story (2026-04-29).
+      // ----------------------------------------------------------------------
+      const signerAddress = await getSignerAddressDynamic(network);
+
+      // Three-output unwrap layout (matches useUnwrapMutation):
+      //   v0: alkanes refund (taproot)        ← refund=v0
+      //   v1: BTC recipient (segwit fallback) ← pointer=v1
+      //   v2: signer P2TR dust                ← dustVout=2
+      const unwrapAlkanesRecipient = isBrowserWallet
+        ? (taprootAddress || segwitAddress)!
+        : 'p2tr:0';
+      const unwrapBtcRecipient = isBrowserWallet
+        ? (segwitAddress || taprootAddress)!
+        : 'p2wpkh:0';
+      const unwrapToAddresses = [unwrapAlkanesRecipient, unwrapBtcRecipient, signerAddress];
+      const UNWRAP_DUST_VOUT = 2;
+
+      // Build unwrap protostone with proper calldata + dust output index.
       const unwrapProtostone = buildUnwrapProtostone({
         frbtcId: FRBTC_ALKANE_ID,
+        dustVout: UNWRAP_DUST_VOUT,
+        amount: minFrbtcOut.toString(),
+        pointer: 'v1',
+        refund: 'v0',
       });
 
       console.log('[SwapUnwrap] Unwrap protostone:', unwrapProtostone);
+      console.log('[SwapUnwrap] Unwrap toAddresses (v0=alk-refund, v1=btc, v2=signer):', unwrapToAddresses);
 
       // For unwrap, we need frBTC input. Build input requirements.
       const [frbtcBlock, frbtcTx] = FRBTC_ALKANE_ID.split(':');
-
-      // Unwrap outputs BTC to segwit address (or taproot if no segwit)
-      const unwrapToAddresses = isBrowserWallet
-        ? [(segwitAddress || taprootAddress)!]
-        : ['p2wpkh:0'];
 
       // Build unwrap using SDK
       const unwrapInputRequirements = `${frbtcBlock}:${frbtcTx}:${minFrbtcOut}`;

--- a/hooks/useUnwrapMutation.ts
+++ b/hooks/useUnwrapMutation.ts
@@ -33,6 +33,34 @@
  * there is an older build missing this opcode. The regtest contract returns:
  *   "ALKANES: revert: Error: Unrecognized opcode" (status: 1)
  * The tier1/unwrap-frbtc.test.ts skip comment applies to REGTEST only.
+ *
+ * ## Calldata Bug Fix (2026-04-29) — `Cannot burn less than dust amount`
+ *
+ * Pre-fix this hook built `buildUnwrapProtostone({ frbtcId })` which produced
+ * the cellpack `[32, 0, 78]` with NO arguments. The contract's signature is
+ * `unwrap(vout: u128, amount_requested: u128)` (see `fr-btc/contract.wit` and
+ * `fr-btc/alkanes.toml`). With the args missing, runtime read `vout = 0`,
+ * `amount_requested = 0`, then `min(0, frbtc_sent) = 0` triggered the
+ * `actual_amount_burn < 546` branch in `fr-btc/src/lib.rs:531-532` →
+ * "Cannot burn less than dust amount" (espo renders this as "dust limit
+ * underflow"). All incoming frBTC was refunded via the `Refund` pointer, so
+ * tokens were never destroyed — the unwrap simply never settled.
+ *
+ * Real-world repro: tx
+ *   `a95597ad69209615a519929b0cc2fb7bddbadd4bce302ec200a838302bfb7eef`
+ * confirmed at block 947162 with the malformed cellpack; the user's frBTC
+ * bounced to vout 1 (verified via `alkanes_protorunesbyoutpoint`).
+ *
+ * Fix: the cellpack must be `[32, 0, 78, dustVout, amount]` AND the tx must
+ * include a P2TR signer dust output at index `dustVout` (the contract's
+ * `burn()` enforces `tx.output[dustVout].script_pubkey == signer_script` —
+ * see `fr-btc/src/lib.rs:262-267`). The signer later spends that dust UTXO
+ * to settle the BTC payment recorded under `/payments/byheight/`.
+ *
+ * Output layout (matches `alkanes-cli/src/main.rs:3192-3197`):
+ *   - output 0: alkanes refund (taproot)         ← refund=v0
+ *   - output 1: BTC recipient (segwit)           ← pointer=v1
+ *   - output 2: signer P2TR dust                 ← dustVout=2
  */
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import * as bitcoin from 'bitcoinjs-lib';
@@ -45,7 +73,7 @@ import { useTransactionConfirm } from '@/context/TransactionConfirmContext';
 import { useSandshrewProvider } from './useSandshrewProvider';
 import { getConfig } from '@/utils/getConfig';
 import { buildUnwrapProtostone, buildUnwrapInputRequirements } from '@/lib/alkanes/builders';
-import { getBitcoinNetwork, extractPsbtBase64, toAlks } from '@/lib/alkanes/helpers';
+import { getBitcoinNetwork, extractPsbtBase64, toAlks, getSignerAddressDynamic } from '@/lib/alkanes/helpers';
 
 bitcoin.initEccLib(ecc);
 
@@ -82,7 +110,9 @@ export function useUnwrapMutation() {
       if (!taprootAddress && !segwitAddress) {
         throw new Error('No wallet address available. Please connect a wallet first.');
       }
-      // For alkane operations, prefer taproot if available (alkanes use P2TR)
+      // For alkane operations, prefer taproot if available (alkanes use P2TR).
+      // The early `throw` above guarantees at least one address; non-null
+      // assertion is applied at call sites that need a `string` (toAddresses).
       const primaryAddress = taprootAddress || segwitAddress;
       console.log('[useUnwrapMutation] Using addresses:', { taprootAddress, segwitAddress, primaryAddress });
 
@@ -93,28 +123,43 @@ export function useUnwrapMutation() {
 
       const unwrapAmount = toAlks(unwrapData.amount);
 
-      // Build protostone for unwrap operation
-      const protostone = buildUnwrapProtostone({
-        frbtcId: FRBTC_ALKANE_ID,
-      });
-
-      // Input requirements: frBTC amount to unwrap
+      // Input requirements: frBTC amount to unwrap (SDK auto-edicts to p0)
       const inputRequirements = buildUnwrapInputRequirements({
         frbtcId: FRBTC_ALKANE_ID,
         amount: unwrapAmount,
       });
 
-      // Get recipient address (taproot for alkanes, but BTC goes to segwit)
+      // BTC recipient. Default to segwit (cheaper); fall back to taproot for
+      // single-address wallets that don't expose a segwit derivation.
       const recipientAddress = account?.nativeSegwit?.address || account?.taproot?.address;
       if (!recipientAddress) throw new Error('No recipient address available');
 
       // Determine btcNetwork for PSBT operations
       const btcNetwork = getBitcoinNetwork(network);
 
+      // ----------------------------------------------------------------------
+      // Resolve the FROST signer's tweaked P2TR address (the dust output).
+      // ----------------------------------------------------------------------
+      // The contract's `burn()` requires `tx.output[dustVout].script_pubkey ==
+      // signer_script` — i.e. one of our outputs MUST be this exact P2TR
+      // script (see fr-btc/src/lib.rs:262-267).
+      //
+      // ALWAYS query dynamically. Opcode 103 returns the internal x-only
+      // pubkey; `getSignerAddressDynamic` derives the BIP341-tweaked P2TR via
+      // bitcoinjs `payments.p2tr`, which is exactly what the on-chain
+      // signer_script encodes. The hardcoded `SIGNER_ADDRESSES.mainnet` was
+      // historically the UNTWEAKED address (bc1p09qw7w...) — using it sends
+      // dust to the wrong script and the contract reverts with
+      // "signer pubkey must be targeted with supplementary output".
+      // Mirrors the perf-branch fix `b3b3a1bf` ("frBTC wrap signer address —
+      // apply BIP341 taproot tweak") for the wrap path.
+      const signerAddress = await getSignerAddressDynamic(network);
+
       console.log('[useUnwrapMutation] Executing unwrap:', {
         amount: unwrapAmount,
         frbtcId: FRBTC_ALKANE_ID,
         recipient: recipientAddress,
+        signer: signerAddress,
         feeRate: unwrapData.feeRate,
       });
 
@@ -131,11 +176,30 @@ export function useUnwrapMutation() {
         ? [segwitAddress, taprootAddress].filter(Boolean) as string[]
         : ['p2wpkh:0', 'p2tr:0'];
 
-      // Unwrap outputs BTC to segwit address (or taproot if no segwit)
-      // TypeScript can't infer from the early return that at least one address exists
+      // ----------------------------------------------------------------------
+      // Three-output unwrap layout (CLI canonical):
+      //   v0: alkanes refund (taproot or primary)   ← refund=v0
+      //   v1: BTC recipient (segwit or fallback)    ← pointer=v1
+      //   v2: FROST signer P2TR dust                ← dustVout=2
+      //
+      // Browser wallets must receive ACTUAL addresses (not symbolic) — same
+      // bug class as 2026-03-01. Keystore takes the symbolic descriptor
+      // branch which the SDK resolves against its loaded mnemonic.
+      // ----------------------------------------------------------------------
+      const DUST_VOUT = 2;
       const toAddresses = useActualAddresses
-        ? [(segwitAddress || taprootAddress)!]
-        : ['p2wpkh:0'];
+        ? [primaryAddress!, (segwitAddress || taprootAddress)!, signerAddress]
+        : ['p2tr:0', 'p2wpkh:0', signerAddress];
+
+      // Build protostone for unwrap operation. MUST include dustVout + amount
+      // in the cellpack — see header comment ("Calldata Bug Fix 2026-04-29").
+      const protostone = buildUnwrapProtostone({
+        frbtcId: FRBTC_ALKANE_ID,
+        dustVout: DUST_VOUT,
+        amount: unwrapAmount,
+        pointer: 'v1', // BTC payment record points at btcRecipient
+        refund: 'v0',  // unspent frBTC bounces back to alkanes recipient
+      });
 
       const changeAddr = useActualAddresses
         ? (segwitAddress || taprootAddress)
@@ -147,7 +211,7 @@ export function useUnwrapMutation() {
         : 'p2tr:0';
 
       console.log('[useUnwrapMutation] From addresses:', fromAddresses, '(browser:', isBrowserWallet, ')');
-      console.log('[useUnwrapMutation] To addresses:', toAddresses);
+      console.log('[useUnwrapMutation] To addresses (v0=alkanes-refund, v1=btc-recipient, v2=signer-dust):', toAddresses);
       console.log('[useUnwrapMutation] Change address:', changeAddr);
 
 

--- a/lib/alkanes/__tests__/builders.test.ts
+++ b/lib/alkanes/__tests__/builders.test.ts
@@ -148,18 +148,37 @@ describe('buildWrapProtostone', () => {
 });
 
 describe('buildUnwrapProtostone', () => {
-  it('builds unwrap protostone with opcode 78', () => {
-    const result = buildUnwrapProtostone({ frbtcId: FRBTC_ID });
-    expect(result).toBe('[32,0,78]:v1:v1');
+  // The cellpack MUST carry [block, tx, 78, dustVout, amount]. Omitting the
+  // last two args caused the 2026-04-29 "dust limit underflow" regression
+  // (real-world tx a95597ad...). See useUnwrapMutation.ts header comment.
+  it('builds unwrap protostone with opcode 78 + dustVout + amount', () => {
+    const result = buildUnwrapProtostone({
+      frbtcId: FRBTC_ID,
+      dustVout: 2,
+      amount: '500000',
+    });
+    expect(result).toBe('[32,0,78,2,500000]:v1:v0');
   });
 
   it('uses custom pointer and refund', () => {
     const result = buildUnwrapProtostone({
       frbtcId: FRBTC_ID,
+      dustVout: 2,
+      amount: '500000',
       pointer: 'v0',
       refund: 'v0',
     });
-    expect(result).toBe('[32,0,78]:v0:v0');
+    expect(result).toBe('[32,0,78,2,500000]:v0:v0');
+  });
+
+  it('threads dustVout through the cellpack (matches CLI canonical layout)', () => {
+    const result = buildUnwrapProtostone({
+      frbtcId: FRBTC_ID,
+      dustVout: 3,
+      amount: '1000',
+    });
+    // Position 4 in the cellpack is dustVout (after block, tx, opcode, then this).
+    expect(result).toContain(',78,3,1000]');
   });
 });
 
@@ -202,11 +221,12 @@ describe('buildSwapUnwrapProtostone', () => {
       factoryId: FACTORY_ID,
       minFrbtcOutput: '50000',
       deadline: '2000',
+      dustVout: 2,
     });
     // p1: swap, pointer=p2 (chains to unwrap)
     expect(result).toContain('[4,65498,13,2,2,0,32,0,1000000,50000,2000]:p2:v0');
-    // p2: unwrap
-    expect(result).toContain('[32,0,78]:v0:v0');
+    // p2: unwrap with dustVout + amount carried in cellpack (2026-04-29 fix)
+    expect(result).toContain('[32,0,78,2,50000]:v0:v0');
   });
 });
 
@@ -366,7 +386,7 @@ describe('builder consistency', () => {
         sellAmount: '100', minOutput: '50', deadline: '100',
       }),
       buildWrapProtostone({ frbtcId: FRBTC_ID }),
-      buildUnwrapProtostone({ frbtcId: FRBTC_ID }),
+      buildUnwrapProtostone({ frbtcId: FRBTC_ID, dustVout: 2, amount: '500000' }),
       buildTransferProtostone({ alkaneId: DIESEL_ID, amount: '100' }),
     ];
 
@@ -393,6 +413,7 @@ describe('builder consistency', () => {
       buildSwapUnwrapProtostone({
         sellTokenId: DIESEL_ID, sellAmount: '100', frbtcId: FRBTC_ID,
         factoryId: FACTORY_ID, minFrbtcOutput: '50', deadline: '100',
+        dustVout: 2,
       }),
     ];
 

--- a/lib/alkanes/builders.ts
+++ b/lib/alkanes/builders.ts
@@ -223,15 +223,46 @@ export function buildWrapProtostone(params: {
 
 /**
  * Build protostone for frBTC → BTC unwrap operation.
+ *
+ * Cellpack: `[32, 0, 78, dustVout, amount]`
+ *
+ * The frBTC contract's `unwrap(vout: u128, amount_requested: u128)` requires
+ * BOTH arguments. With them omitted (the long-standing bug), the runtime read
+ * `vout = 0`, `amount_requested = 0`, then `min(0, frbtc_sent) = 0` triggered
+ * the `actual_amount_burn < 546` branch → `Cannot burn less than dust amount`
+ * (espo renders this as "dust limit underflow"). All incoming frBTC was then
+ * refunded via the `Refund` pointer — tokens were not destroyed but the
+ * unwrap never settled. See `fr-btc/src/lib.rs:519-545`.
+ *
+ * `dustVout` is the index of a P2TR output in this same tx that pays the
+ * FROST signer's tweaked address. The contract's `burn()` enforces
+ * `tx.output[dustVout].script_pubkey == signer_script`; the signer later
+ * spends that dust UTXO to settle the BTC payment via the `Payment` records
+ * stored under `/payments/byheight/`. The CLI canonical layout
+ * (`alkanes-cli/src/main.rs:3192-3197`) is:
+ *   - output 0: alkanes refund (taproot)
+ *   - output 1: BTC recipient (segwit) — destination for the queued BTC payment
+ *   - output 2: signer dust (P2TR) — `dustVout = 2`
+ * with `pointer = 'v1'` (BTC recipient) and `refund = 'v0'` (alkanes refund).
+ *
+ * Source: see `fr-btc/contract.wit` (signature) + `fr-btc/alkanes.toml`
+ *         (opcode 78) + `alkanes-cli/src/main.rs:3477-3502`
+ *         (`build_unwrap_protostone`).
  */
 export function buildUnwrapProtostone(params: {
   frbtcId: string;
+  /** Index of the P2TR signer dust output in this tx (the `vout` arg). */
+  dustVout: number;
+  /** frBTC amount to burn, in u128 sats (the `amount_requested` arg). */
+  amount: string;
+  /** Where the unwrapped BTC payment (queued for signer) is recorded. Default `v1`. */
   pointer?: string;
+  /** Where unspent frBTC bounces back. Default `v0` (alkanes recipient). */
   refund?: string;
 }): string {
-  const { frbtcId, pointer = 'v1', refund = 'v1' } = params;
+  const { frbtcId, dustVout, amount, pointer = 'v1', refund = 'v0' } = params;
   const [frbtcBlock, frbtcTx] = frbtcId.split(':');
-  const cellpack = [frbtcBlock, frbtcTx, FRBTC_UNWRAP_OPCODE].join(',');
+  const cellpack = [frbtcBlock, frbtcTx, FRBTC_UNWRAP_OPCODE, dustVout, amount].join(',');
   return `[${cellpack}]:${pointer}:${refund}`;
 }
 
@@ -365,7 +396,16 @@ export function buildWrapSwapProtostone(params: {
  * the edict at p0 from inputRequirements:
  *   p0: SDK auto-edict → sends sell tokens to p1
  *   p1: Swap cellpack → pointer=p2 forwards frBTC
- *   p2: Unwrap cellpack → outputs BTC to v0
+ *   p2: Unwrap cellpack → outputs BTC at `pointer` (default v0)
+ *
+ * The caller MUST include a P2TR signer dust output at index `dustVout` in
+ * the tx outputs — otherwise the unwrap reverts with "Cannot burn less than
+ * dust amount" (vout/amount default to 0). See `buildUnwrapProtostone` for
+ * the full explanation of the cellpack layout and `fr-btc/src/lib.rs:519-545`
+ * for the contract source.
+ *
+ * NOTE: this atomic two-protostone path is DEPRECATED in favor of the two-tx
+ * pattern in `useSwapUnwrapMutation`. Kept here for reference/tests.
  */
 export function buildSwapUnwrapProtostone(params: {
   sellTokenId: string;
@@ -374,8 +414,10 @@ export function buildSwapUnwrapProtostone(params: {
   factoryId: string;
   minFrbtcOutput: string;
   deadline: string;
+  /** Index of the P2TR signer dust output in this tx. */
+  dustVout: number;
 }): string {
-  const { sellTokenId, sellAmount, frbtcId, factoryId, minFrbtcOutput, deadline } = params;
+  const { sellTokenId, sellAmount, frbtcId, factoryId, minFrbtcOutput, deadline, dustVout } = params;
 
   const [sellBlock, sellTx] = sellTokenId.split(':');
   const [frbtcBlock, frbtcTx] = frbtcId.split(':');
@@ -396,7 +438,10 @@ export function buildSwapUnwrapProtostone(params: {
   ].join(',');
   const p1 = `[${swapCellpack}]:p2:v0`;
 
-  const unwrapCellpack = [frbtcBlock, frbtcTx, FRBTC_UNWRAP_OPCODE].join(',');
+  // Cellpack args: [..., 78, dustVout, amount]. Use minFrbtcOutput as the
+  // amount_requested ceiling — the contract `min()`s against actual frBTC
+  // received from the swap.
+  const unwrapCellpack = [frbtcBlock, frbtcTx, FRBTC_UNWRAP_OPCODE, dustVout, minFrbtcOutput].join(',');
   const p2 = `[${unwrapCellpack}]:v0:v0`;
 
   return `${p1},${p2}`;


### PR DESCRIPTION
## Summary

- `buildUnwrapProtostone` now emits the full cellpack `[32, 0, 78, dustVout, amount]` matching the contract's `unwrap(vout, amount_requested)` signature
- `useUnwrapMutation` and `useSwapUnwrapMutation` now build the canonical 3-output layout `[alkanes_refund, btc_recipient, signer_dust]` with the FROST signer's BIP341-tweaked P2TR at `dustVout = 2`
- Signer address resolved via `getSignerAddressDynamic(network)` so the dust output matches the on-chain `signer_script` at runtime

## Why

The contract's `unwrap(vout, amount_requested)` requires both arguments. Pre-fix the cellpack omitted them, so the runtime read `vout = 0`, `amount_requested = 0`, then `min(0, frbtc_sent) = 0` triggered the `< 546` branch in `fr-btc/src/lib.rs:531-532` → revert with `Cannot burn less than dust amount` (espo renders as "dust limit underflow"). All incoming frBTC bounced via the `Refund` pointer — tokens never destroyed, unwrap never settled.

Real-world repro: mainnet tx `a95597ad69209615a519929b0cc2fb7bddbadd4bce302ec200a838302bfb7eef` (block 947162). User's frBTC bounced to vout 1, verified via `alkanes_protorunesbyoutpoint`.

The contract's `burn()` additionally enforces `tx.output[dustVout].script_pubkey == signer_script` (`fr-btc/src/lib.rs:262-267`). The new 3-output layout puts the BIP341-tweaked signer P2TR at vout 2 to satisfy that check; the signer later spends that dust UTXO to settle the queued BTC payment recorded under `/payments/byheight/`.

## Verification

End-to-end mainnet verification: tx `e9c8db6d7ea264c18d5525e74fc19dc8113ee1dfbc4f631d135e93cfa1051009` carries cellpack `[32, 0, 78, 2, 2000]` with the tweaked signer at vout 2, matching contract expectations.

Per-wallet correctness audit (UniSat / OYL / Xverse / Keystore): the fix lives at the protocol layer (calldata + output structure). Wallet-specific signing machinery (`patchInputsOnly`, `signTaprootPsbt`, per-wallet routing in `WalletContext`) is unchanged and already proven by the wrap path.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run hooks/__tests__/mutations/ lib/alkanes/__tests__/` → 501/501 pass
- [x] Mainnet UniSat unwrap end-to-end (tx `e9c8db6d...`)
- [ ] OYL mainnet unwrap (one click)
- [ ] Xverse mainnet unwrap (one click)
- [ ] Keystore mainnet unwrap (one click)

## References

- `fr-btc/contract.wit` (signature)
- `fr-btc/alkanes.toml` (opcode 78)
- `alkanes-cli/src/main.rs:3192-3197, 3477-3502` (canonical CLI implementation)
- `fr-btc/src/lib.rs:519-545` (unwrap), `:262-267` (burn signer check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)