### PR TITLE
feat(wallet): account switcher dropdown + simplify derivation settings

### DIFF
--- a/app/components/AccountSwitcher.tsx
+++ b/app/components/AccountSwitcher.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { Plus, Check, ChevronDown } from 'lucide-react';
+import { useWallet } from '@/context/WalletContext';
+import { AddressType } from '@alkanes/ts-sdk';
+import AddressAvatar from './AddressAvatar';
+
+const ADDRESS_INDEX_KEY = 'subfrost_taproot_address_index';
+const ACCOUNT_LIST_KEY = 'subfrost_known_account_indices';
+const MAX_ACCOUNTS = 10;
+
+function loadKnownIndices(): number[] {
+  if (typeof localStorage === 'undefined') return [0];
+  try {
+    const raw = localStorage.getItem(ACCOUNT_LIST_KEY);
+    if (!raw) return [0];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [0];
+    const filtered = parsed
+      .map((n) => Number(n))
+      .filter((n) => Number.isInteger(n) && n >= 0)
+      .sort((a, b) => a - b);
+    return filtered.length > 0 ? filtered : [0];
+  } catch {
+    return [0];
+  }
+}
+
+function saveKnownIndices(indices: number[]): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(ACCOUNT_LIST_KEY, JSON.stringify(indices));
+}
+
+interface AccountSwitcherProps {
+  size?: number;
+  className?: string;
+}
+
+export default function AccountSwitcher({ size = 24, className = '' }: AccountSwitcherProps) {
+  const { wallet, walletType, address: currentAddress } = useWallet() as any;
+  const [open, setOpen] = useState(false);
+  const [knownIndices, setKnownIndices] = useState<number[]>(() => loadKnownIndices());
+  const [activeIndex, setActiveIndex] = useState<number>(() => {
+    if (typeof localStorage === 'undefined') return 0;
+    return parseInt(localStorage.getItem(ADDRESS_INDEX_KEY) || '0', 10) || 0;
+  });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Sync activeIndex with localStorage on derivation-changed
+  useEffect(() => {
+    const handler = () => {
+      const idx = parseInt(localStorage.getItem(ADDRESS_INDEX_KEY) || '0', 10) || 0;
+      setActiveIndex(idx);
+    };
+    window.addEventListener('derivation-changed', handler);
+    return () => window.removeEventListener('derivation-changed', handler);
+  }, []);
+
+  // Ensure activeIndex is in knownIndices (e.g. user set it via Settings)
+  useEffect(() => {
+    if (!knownIndices.includes(activeIndex)) {
+      const next = [...knownIndices, activeIndex].sort((a, b) => a - b);
+      setKnownIndices(next);
+      saveKnownIndices(next);
+    }
+  }, [activeIndex, knownIndices]);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  // Derive address for a given index using the SDK wallet shim.
+  // Shim signature: deriveAddress(type, account /* unused */, index)
+  const deriveAddressAt = (index: number): string => {
+    if (!wallet) return '';
+    try {
+      const info = wallet.deriveAddress(AddressType.P2TR, 0, index);
+      return info?.address || '';
+    } catch {
+      return '';
+    }
+  };
+
+  const accounts = useMemo(
+    () => knownIndices.map((idx) => ({ idx, address: deriveAddressAt(idx) })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [knownIndices, wallet],
+  );
+
+  const switchTo = (idx: number) => {
+    localStorage.setItem(ADDRESS_INDEX_KEY, String(idx));
+    window.dispatchEvent(new CustomEvent('derivation-changed'));
+    setActiveIndex(idx);
+    setOpen(false);
+  };
+
+  const addAccount = () => {
+    const next = (knownIndices[knownIndices.length - 1] ?? -1) + 1;
+    if (next >= MAX_ACCOUNTS) return;
+    const updated = [...knownIndices, next].sort((a, b) => a - b);
+    setKnownIndices(updated);
+    saveKnownIndices(updated);
+    switchTo(next);
+  };
+
+  // Only show switcher for keystore wallets — browser wallets have their own
+  // account management via the extension popup.
+  if (walletType !== 'keystore') {
+    return <AddressAvatar address={currentAddress || ''} size={size} className={className} />;
+  }
+
+  const truncate = (addr: string) =>
+    addr.length > 16 ? `${addr.slice(0, 8)}...${addr.slice(-6)}` : addr;
+
+  return (
+    <div ref={containerRef} className={`relative ${className}`}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1 rounded-md hover:bg-[color:var(--sf-surface)] transition-all duration-[400ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none p-0.5"
+        title="Switch account"
+      >
+        <AddressAvatar address={currentAddress || ''} size={size} />
+        <ChevronDown
+          size={12}
+          className={`text-[color:var(--sf-text)]/60 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full z-50 mt-2 w-[280px] overflow-hidden rounded-xl bg-[color:var(--sf-surface)] shadow-[0_8px_24px_rgba(0,0,0,0.18)] border border-[color:var(--sf-outline)]">
+          <div className="px-3 py-2 text-[11px] uppercase tracking-wider font-bold text-[color:var(--sf-text)]/40 border-b border-[color:var(--sf-outline)]">
+            Accounts
+          </div>
+          <div className="max-h-[280px] overflow-y-auto no-scrollbar">
+            {accounts.map(({ idx, address }) => {
+              const isActive = idx === activeIndex;
+              return (
+                <button
+                  key={idx}
+                  type="button"
+                  onClick={() => switchTo(idx)}
+                  className={`w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-[color:var(--sf-primary)]/10 transition-all duration-[200ms] ${
+                    isActive ? 'bg-[color:var(--sf-primary)]/5' : ''
+                  }`}
+                >
+                  <AddressAvatar address={address} size={28} className="shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium text-[color:var(--sf-text)]">
+                      Account {idx}
+                    </div>
+                    <div className="text-[11px] text-[color:var(--sf-text)]/50 truncate font-mono">
+                      {truncate(address)}
+                    </div>
+                  </div>
+                  {isActive && (
+                    <Check size={16} className="shrink-0 text-[color:var(--sf-primary)]" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+          {knownIndices.length < MAX_ACCOUNTS && (
+            <button
+              type="button"
+              onClick={addAccount}
+              className="w-full flex items-center gap-2 px-3 py-2.5 border-t border-[color:var(--sf-outline)] hover:bg-[color:var(--sf-primary)]/10 transition-all duration-[200ms] text-[color:var(--sf-primary)] text-sm font-medium"
+            >
+              <Plus size={16} />
+              Add Account
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/wallet/components/TransactionHistory.tsx
+++ b/app/wallet/components/TransactionHistory.tsx
@@ -89,7 +89,7 @@ const TransactionHistory = forwardRef<TransactionHistoryHandle>(function Transac
 
   return (
     <div>
-      <div ref={scrollRef} className="space-y-2 max-h-[308px] lg:max-h-[752px] overflow-y-auto pr-1">
+      <div ref={scrollRef} className="space-y-2 max-h-[308px] lg:max-h-[752px] overflow-y-auto pr-1 no-scrollbar">
         {transactions.length > 0 ? (
           <>
             {transactions.map((tx) => (

--- a/app/wallet/components/WalletSettings.tsx
+++ b/app/wallet/components/WalletSettings.tsx
@@ -75,12 +75,17 @@ export default function WalletSettings() {
   const [customDataApiUrl, setCustomDataApiUrl] = useState('');
   const [customSandshrewUrl, setCustomSandshrewUrl] = useState('');
 
-  // Derivation config
-  const [taprootConfig, setTaprootConfig] = useState<DerivationConfig>({
+  // Derivation config — only addressIndex is functional (SDK only exposes it).
+  // Account and changeIndex are kept in state to render preview path but cannot
+  // be saved to disk: the SDK ignores them and would silently desync the
+  // displayed address from the signing key.
+  const [taprootConfig, setTaprootConfig] = useState<DerivationConfig>(() => ({
     accountIndex: 0,
     changeIndex: 0,
-    addressIndex: 0,
-  });
+    addressIndex: typeof localStorage !== 'undefined'
+      ? parseInt(localStorage.getItem('subfrost_taproot_address_index') || '0', 10) || 0
+      : 0,
+  }));
   const [segwitConfig, setSegwitConfig] = useState<DerivationConfig>({
     accountIndex: 0,
     changeIndex: 0,
@@ -244,8 +249,9 @@ export default function WalletSettings() {
     // Save network to localStorage
     localStorage.setItem('subfrost_selected_network', network);
 
-    // Save taproot account index
-    localStorage.setItem('subfrost_taproot_account_index', String(taprootConfig.accountIndex));
+    // Save taproot address index (last segment of BIP-86 path).
+    // SDK only exposes the address index — account/change are fixed at 0.
+    localStorage.setItem('subfrost_taproot_address_index', String(taprootConfig.addressIndex));
 
     // Dispatch custom event to notify other components (same tab)
     window.dispatchEvent(new CustomEvent('network-changed', { detail: network }));
@@ -607,52 +613,7 @@ export default function WalletSettings() {
                         {t('settings.taprootBip86')} - {taprootPath}
                       </label>
                     </div>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                      <div>
-                        <label className="block text-xs text-[color:var(--sf-text)]/60 mb-1">{t('settings.account')}</label>
-                        <input
-                          type="number"
-                          min="0"
-                          max="2147483647"
-                          value={taprootConfig.accountIndex}
-                          onChange={(e) => setTaprootConfig({ ...taprootConfig, accountIndex: parseInt(e.target.value) || 0 })}
-                          className="w-full rounded-lg border border-[color:var(--sf-outline)] bg-[color:var(--sf-primary)]/5 px-3 py-2 text-sm text-[color:var(--sf-text)] outline-none focus:border-[color:var(--sf-primary)]"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs text-[color:var(--sf-text)]/60 mb-1">{t('settings.change')}</label>
-                        <div className="relative" ref={taprootChangeDropdownRef}>
-                          <button
-                            type="button"
-                            onClick={() => setTaprootChangeDropdownOpen((v) => !v)}
-                            className="w-full flex items-center gap-2 rounded-xl bg-[color:var(--sf-surface)] shadow-[0_2px_8px_rgba(0,0,0,0.15)] px-4 py-3 text-sm text-[color:var(--sf-text)] hover:bg-[color:var(--sf-primary)]/10 transition-all duration-[400ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none cursor-pointer"
-                          >
-                            <span className="flex-1 text-left">{CHANGE_OPTIONS.find((o) => o.value === taprootConfig.changeIndex)?.label ?? 'External (0)'}</span>
-                            <ChevronDown size={16} className={`transition-all duration-[400ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none ${taprootChangeDropdownOpen ? 'rotate-180' : ''}`} />
-                          </button>
-                          {taprootChangeDropdownOpen && (
-                            <div className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-xl bg-[color:var(--sf-surface)] backdrop-blur-xl shadow-[0_8px_24px_rgba(0,0,0,0.12)]">
-                              {CHANGE_OPTIONS.map((option) => (
-                                <button
-                                  key={option.value}
-                                  type="button"
-                                  onClick={() => {
-                                    setTaprootConfig({ ...taprootConfig, changeIndex: option.value });
-                                    setTaprootChangeDropdownOpen(false);
-                                  }}
-                                  className={`w-full px-4 py-2.5 text-left text-sm font-medium transition-all duration-[400ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none ${
-                                    taprootConfig.changeIndex === option.value
-                                      ? 'bg-[color:var(--sf-primary)]/10 text-[color:var(--sf-primary)]'
-                                      : 'text-[color:var(--sf-text)] hover:bg-[color:var(--sf-primary)]/10'
-                                  }`}
-                                >
-                                  {option.label}
-                                </button>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      </div>
+                    <div className="grid grid-cols-1 gap-3">
                       <div>
                         <label className="block text-xs text-[color:var(--sf-text)]/60 mb-1">{t('settings.addressIndex')}</label>
                         <input
@@ -692,52 +653,7 @@ export default function WalletSettings() {
                         {t('settings.segwitBip84')} - {segwitPath}
                       </label>
                     </div>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                      <div>
-                        <label className="block text-xs text-[color:var(--sf-text)]/60 mb-1">{t('settings.account')}</label>
-                        <input
-                          type="number"
-                          min="0"
-                          max="2147483647"
-                          value={segwitConfig.accountIndex}
-                          onChange={(e) => setSegwitConfig({ ...segwitConfig, accountIndex: parseInt(e.target.value) || 0 })}
-                          className="w-full rounded-lg border border-[color:var(--sf-outline)] bg-[color:var(--sf-primary)]/5 px-3 py-2 text-sm text-[color:var(--sf-text)] outline-none focus:border-[color:var(--sf-primary)]"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs text-[color:var(--sf-text)]/60 mb-1">{t('settings.change')}</label>
-                        <div className="relative" ref={segwitChangeDropdownRef}>
-                          <button
-                            type="button"
-                            onClick={() => setSegwitChangeDropdownOpen((v) => !v)}
-                            className="w-full flex items-center gap-2 rounded-xl bg-[color:var(--sf-surface)] shadow-[0_2px_8px_rgba(0,0,0,0.15)] px-4 py-3 text-sm text-[color:var(--sf-text)] hover:bg-[color:var(--sf-primary)]/10 transition-all duration-[400ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none cursor-pointer"
-                          >
-                            <span className="flex-1 text-left">{CHANGE_OPTIONS.find((o) => o.value === segwitConfig.changeIndex)?.label ?? 'External (0)'}</span>
-                            <ChevronDown size={16} className={`transition-all duration-[400ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none ${segwitChangeDropdownOpen ? 'rotate-180' : ''}`} />
-                          </button>
-                          {segwitChangeDropdownOpen && (
-                            <div className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-xl bg-[color:var(--sf-surface)] backdrop-blur-xl shadow-[0_8px_24px_rgba(0,0,0,0.12)]">
-                              {CHANGE_OPTIONS.map((option) => (
-                                <button
-                                  key={option.value}
-                                  type="button"
-                                  onClick={() => {
-                                    setSegwitConfig({ ...segwitConfig, changeIndex: option.value });
-                                    setSegwitChangeDropdownOpen(false);
-                                  }}
-                                  className={`w-full px-4 py-2.5 text-left text-sm font-medium transition-all duration-[400ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none ${
-                                    segwitConfig.changeIndex === option.value
-                                      ? 'bg-[color:var(--sf-primary)]/10 text-[color:var(--sf-primary)]'
-                                      : 'text-[color:var(--sf-text)] hover:bg-[color:var(--sf-primary)]/10'
-                                  }`}
-                                >
-                                  {option.label}
-                                </button>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      </div>
+                    <div className="grid grid-cols-1 gap-3">
                       <div>
                         <label className="block text-xs text-[color:var(--sf-text)]/60 mb-1">{t('settings.addressIndex')}</label>
                         <input

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -7,6 +7,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Wallet, Activity, Settings, BarChart2, Send, QrCode, Copy, Check, RefreshCw } from 'lucide-react';
 import { useTranslation } from '@/hooks/useTranslation';
 import AddressAvatar from '@/app/components/AddressAvatar';
+import AccountSwitcher from '@/app/components/AccountSwitcher';
 import BitcoinBalanceCard from './components/BitcoinBalanceCard';
 import AlkanesBalancesCard from './components/AlkanesBalancesCard';
 import UTXOManagement from './components/UTXOManagement';
@@ -133,7 +134,7 @@ export default function WalletDashboardPage() {
             )}
             {address && (
               <div className="flex items-center gap-3">
-                <AddressAvatar address={address} size={24} className="shrink-0" />
+                <AccountSwitcher size={24} className="shrink-0" />
                 <span className="text-xs sm:text-sm text-[color:var(--sf-text)]/60 whitespace-nowrap">
                   {t('walletDash.taproot')}
                 </span>

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -347,7 +347,7 @@ const STORAGE_KEYS = {
   BROWSER_WALLET_ID: 'subfrost_browser_wallet_id', // Last connected browser wallet ID
   WALLET_TYPE: 'subfrost_wallet_type', // 'keystore' or 'browser'
   BROWSER_WALLET_ADDRESSES: 'subfrost_browser_wallet_addresses', // Cached addresses to avoid re-prompting
-  TAPROOT_ACCOUNT_INDEX: 'subfrost_taproot_account_index', // BIP86 account index for keystore
+  TAPROOT_ADDRESS_INDEX: 'subfrost_taproot_address_index', // BIP86 address index (last segment) for keystore
 } as const;
 
 type WalletContextType = {
@@ -416,9 +416,11 @@ export function WalletProvider({ children, network }: WalletProviderProps) {
   const [isInitializing, setIsInitializing] = useState(true);
   const [wallet, setWallet] = useState<AlkanesWallet | null>(null);
   const [hasStoredKeystore, setHasStoredKeystore] = useState(false);
-  const [taprootAccountIndex, setTaprootAccountIndex] = useState(() =>
+  // Taproot address index (last segment of m/86'/coinType'/0'/0/N).
+  // SDK only exposes this segment — account/change are fixed at 0.
+  const [taprootAddressIndex, setTaprootAddressIndex] = useState(() =>
     typeof localStorage !== 'undefined'
-      ? parseInt(localStorage.getItem(STORAGE_KEYS.TAPROOT_ACCOUNT_INDEX) || '0', 10) || 0
+      ? parseInt(localStorage.getItem(STORAGE_KEYS.TAPROOT_ADDRESS_INDEX) || '0', 10) || 0
       : 0
   );
 
@@ -575,11 +577,11 @@ export function WalletProvider({ children, network }: WalletProviderProps) {
     initializeWallet();
   }, [network, sdkInitialized, loadWallet, getWalletConnector]);
 
-  // Listen for account index changes from WalletSettings
+  // Listen for address index changes from WalletSettings
   useEffect(() => {
     const handler = () => {
-      const idx = parseInt(localStorage.getItem(STORAGE_KEYS.TAPROOT_ACCOUNT_INDEX) || '0', 10) || 0;
-      setTaprootAccountIndex(idx);
+      const idx = parseInt(localStorage.getItem(STORAGE_KEYS.TAPROOT_ADDRESS_INDEX) || '0', 10) || 0;
+      setTaprootAddressIndex(idx);
     };
     window.addEventListener('derivation-changed', handler);
     return () => window.removeEventListener('derivation-changed', handler);
@@ -752,7 +754,10 @@ export function WalletProvider({ children, network }: WalletProviderProps) {
     }
 
     let segwitInfo = { address: '', publicKey: '' };
-    let taprootInfo = wallet.deriveAddress(AddressType.P2TR, taprootAccountIndex, 0);
+    // NOTE: createWalletViaClient shim signature is (type, account, index) but
+    // only the third arg reaches the SDK signer. Pass our address index as the
+    // third arg or it's silently ignored.
+    let taprootInfo = wallet.deriveAddress(AddressType.P2TR, 0, taprootAddressIndex);
 
     // No coinType override needed — createWalletViaClient uses AlkanesClient.withMnemonic
     // which correctly derives coinType=1 for regtest/devnet, coinType=0 for mainnet.
@@ -788,7 +793,7 @@ export function WalletProvider({ children, network }: WalletProviderProps) {
       },
       zcash: zcashInfo || undefined,
     };
-  }, [wallet, browserWallet, walletType, browserWalletAddresses, network, taprootAccountIndex]);
+  }, [wallet, browserWallet, walletType, browserWalletAddresses, network, taprootAddressIndex]);
 
   // Build account structure
   const account: Account = useMemo(() => {


### PR DESCRIPTION
- Add AccountSwitcher component on Wallet Dashboard (keystore only): click avatar → dropdown with all accounts + Add Account button
- Persist known account list in localStorage (subfrost_known_account_indices)
- Rename taprootAccountIndex → taprootAddressIndex (semantically correct: SDK only exposes the last path segment; account/change are fixed at 0)
- Fix createWalletViaClient shim arg position: address index must be the third arg (not second) or it is silently ignored
- Strip non-functional Account/Change inputs from WalletSettings advanced config — leave only Address Index since SDK ignores the rest
- Hide scrollbar in Wallet Dashboard transaction history