### PR TITLE
fix(devnet): route RPC to in-browser harness, complete full boot

### DIFF
--- a/app/wallet/components/SendModal.tsx
+++ b/app/wallet/components/SendModal.tsx
@@ -299,7 +299,10 @@ export default function SendModal({ isOpen, onClose, initialAlkane, onSuccess }:
     if (!isOpen) return;
     const addresses = [account?.taproot?.address, account?.nativeSegwit?.address].filter(Boolean);
     if (addresses.length === 0) return;
-    const rpcPath = network ? `/api/rpc/${network}` : '/api/rpc';
+    // JOURNAL (2026-04-30): on devnet, hit the in-browser harness directly via
+    // localhost:18888 (the fetch interceptor catches it). The /api/rpc/devnet
+    // server proxy can't reach an in-browser indexer and returns 503.
+    const rpcPath = network === 'devnet' ? 'http://localhost:18888' : (network ? `/api/rpc/${network}` : '/api/rpc');
     const isRegtest = network === 'regtest' || network === 'regtest-local' || network === 'subfrost-regtest' || network === 'qubitcoin-regtest';
 
     (async () => {

--- a/lib/alkanes/buildAlkaneTransferPsbt.ts
+++ b/lib/alkanes/buildAlkaneTransferPsbt.ts
@@ -130,7 +130,11 @@ async function fetchUtxos(address: string, networkName?: string): Promise<Simple
   };
   console.log('[fetchUtxos] RPC request:', JSON.stringify(rpcBody));
 
-  const resp = await fetch('/api/rpc', {
+  // JOURNAL (2026-04-30): on devnet, hit the in-browser harness directly via
+  // localhost:18888 (the fetch interceptor catches it). The /api/rpc server
+  // proxy returns 500 for devnet because it can't reach an in-browser indexer.
+  const rpcUrl = networkName === 'devnet' ? 'http://localhost:18888' : '/api/rpc';
+  const resp = await fetch(rpcUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(rpcBody),
@@ -140,7 +144,22 @@ async function fetchUtxos(address: string, networkName?: string): Promise<Simple
   const json = await resp.json();
   console.log('[fetchUtxos] RPC response:', JSON.stringify(json).slice(0, 500));
 
-  // If JSON-RPC returns empty/null, fall back to REST API
+  // JOURNAL (2026-04-30): on devnet, the in-browser harness JSON-RPC is authoritative.
+  // Skip the REST fallback — `/api/esplora/...?network=devnet` returns 500 because the
+  // server-side proxy can't reach the in-browser indexer. An empty result here means
+  // the address truly has no UTXOs.
+  if (networkName === 'devnet') {
+    const utxos = (Array.isArray(json.result) ? json.result : []).map((u: any) => ({
+      txid: u.txid,
+      vout: u.vout,
+      value: u.value,
+      confirmed: u.status?.confirmed ?? false,
+    }));
+    console.log('[fetchUtxos] Devnet JSON-RPC authoritative, found', utxos.length, 'UTXOs');
+    return utxos;
+  }
+
+  // On mainnet, JSON-RPC sometimes returns empty even when UTXOs exist — fall back to REST.
   if (!json.result || !Array.isArray(json.result) || json.result.length === 0) {
     console.log('[fetchUtxos] JSON-RPC returned empty, trying REST API fallback...');
 
@@ -201,12 +220,17 @@ async function fetchOrdOutputs(address: string, networkName?: string): Promise<O
   console.log('[fetchOrdOutputs] Fetching ord outputs for:', address);
 
   // Determine the RPC endpoint based on network
+  // JOURNAL (2026-04-30): added 'devnet' so the in-browser fetch interceptor
+  // catches this and dispatches to the in-process WASM indexer. Without this
+  // entry, devnet falls through to mainnet and queries a chain that has none
+  // of the user's outpoints, surfacing as "No UTXOs found containing alkane".
   const RPC_ENDPOINTS: Record<string, string> = {
     mainnet: 'https://mainnet.subfrost.io/v4/subfrost',
     testnet: 'https://testnet.subfrost.io/v4/subfrost',
     signet: 'https://signet.subfrost.io/v4/subfrost',
     regtest: 'https://regtest.subfrost.io/v4/subfrost',
     'regtest-local': 'http://localhost:18888',
+    devnet: 'http://localhost:18888',
     'subfrost-regtest': 'https://regtest.subfrost.io/v4/subfrost',
     oylnet: 'https://regtest.subfrost.io/v4/subfrost',
   };
@@ -277,12 +301,17 @@ async function fetchAlkaneOutpoints(address: string, networkName?: string): Prom
   console.log('[fetchAlkaneOutpoints] Fetching alkane outpoints for:', address);
 
   // Determine the RPC endpoint based on network
+  // JOURNAL (2026-04-30): added 'devnet' so the in-browser fetch interceptor
+  // catches this and dispatches to the in-process WASM indexer. Without this
+  // entry, devnet falls through to mainnet and queries a chain that has none
+  // of the user's outpoints, surfacing as "No UTXOs found containing alkane".
   const RPC_ENDPOINTS: Record<string, string> = {
     mainnet: 'https://mainnet.subfrost.io/v4/subfrost',
     testnet: 'https://testnet.subfrost.io/v4/subfrost',
     signet: 'https://signet.subfrost.io/v4/subfrost',
     regtest: 'https://regtest.subfrost.io/v4/subfrost',
     'regtest-local': 'http://localhost:18888',
+    devnet: 'http://localhost:18888',
     'subfrost-regtest': 'https://regtest.subfrost.io/v4/subfrost',
     oylnet: 'https://regtest.subfrost.io/v4/subfrost',
   };

--- a/lib/devnet/boot.ts
+++ b/lib/devnet/boot.ts
@@ -231,6 +231,49 @@ export async function bootDevnetWithWasms(
   // Install fetch interceptor — all RPC calls now go in-process
   _harness.installFetchInterceptor();
 
+  // JOURNAL (2026-04-30): SDK presign-RBF path uses Bitcoin Core's batch
+  // `sendrawtransactions` (plural) RPC, but the qubitcoin in-browser harness
+  // only supports `sendrawtransaction` (singular). Wrap fetch to translate
+  // batch calls into N singular calls in order. Without this, every
+  // commit/reveal envelope deploy (FIRE Bonding, FIRE Token, etc.) fails
+  // with "Bitcoin method not supported in devnet: sendrawtransactions".
+  if (typeof globalThis !== 'undefined' && globalThis.fetch) {
+    const harnessFetch = globalThis.fetch;
+    const sendrawTranslator: typeof fetch = async (input: any, init: any) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.toString() : input.url);
+      const method = init?.method?.toUpperCase() ?? 'GET';
+      const isHarness = url?.startsWith('http://localhost:18888') || url?.startsWith('http://127.0.0.1:18888');
+      if (method === 'POST' && isHarness && init?.body) {
+        try {
+          const body = typeof init.body === 'string' ? init.body : await new Response(init.body).text();
+          const parsed = JSON.parse(body);
+          if (parsed.method === 'sendrawtransactions' || parsed.method === 'btc_sendrawtransactions') {
+            const txHexes: string[] = Array.isArray(parsed.params?.[0]) ? parsed.params[0] : parsed.params;
+            const results: string[] = [];
+            for (const txHex of txHexes) {
+              const r = await harnessFetch.call(globalThis, url, {
+                ...init,
+                body: JSON.stringify({ jsonrpc: '2.0', method: 'btc_sendrawtransaction', params: [txHex], id: parsed.id }),
+              });
+              const j: any = await r.json();
+              if (j.error) {
+                return new Response(JSON.stringify({ jsonrpc: '2.0', error: j.error, id: parsed.id }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+              }
+              results.push(j.result);
+            }
+            return new Response(JSON.stringify({ jsonrpc: '2.0', result: results, id: parsed.id }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+          }
+        } catch {
+          // Fall through to harness fetch on parse error
+        }
+      }
+      return harnessFetch.call(globalThis, input, init);
+    };
+    globalThis.fetch = sendrawTranslator;
+    if (globalThis.window) globalThis.window.fetch = sendrawTranslator;
+    console.log('[devnet-boot] Installed sendrawtransactions → sendrawtransaction translator');
+  }
+
   // If we have a saved state, import it instead of mining blocks
   if (savedState) {
     onProgress('Restoring saved state...', 20);
@@ -666,18 +709,26 @@ async function executeCall(
     // WASM PSBT builder is O(n²) and blocks the JS thread indefinitely with both addresses.
     // Taproot has ~5 UTXOs (dust from alkane ops), completes in ~200ms.
     const fromAddresses = fromAddressesOverride ?? [segwit, taproot];
+    // JOURNAL (2026-04-30): when from_addresses is taproot-only (used to avoid
+    // UTXO-bloat hangs in late-boot txns), the SDK's default protect_taproot=true
+    // makes taproot UTXOs ineligible for fees, leaving zero candidates and
+    // failing with "Insufficient funds: have 0 (protect_taproot=true)". When
+    // we're explicitly funding from taproot, we must opt out of the protection.
+    const isTaprootOnly = fromAddresses.length === 1 && fromAddresses[0] === taproot;
+    const options: any = {
+      from_addresses: fromAddresses,
+      change_address: fromAddresses[0] === taproot ? taproot : segwit,
+      alkanes_change_address: taproot,
+      mine_enabled: true,
+    };
+    if (isTaprootOnly) options.protect_taproot = false;
     const result = await provider.alkanesExecuteFull(
       JSON.stringify(toAddresses || [taproot]),
       inputRequirements,
       protostone,
       '1',
       null,
-      JSON.stringify({
-        from_addresses: fromAddresses,
-        change_address: fromAddresses[0] === taproot ? taproot : segwit,
-        alkanes_change_address: taproot,
-        mine_enabled: true,
-      }),
+      JSON.stringify(options),
     );
     const txid = result?.txid || result?.reveal_txid || result?.revealTxid || '';
     _lastTxid = txid;


### PR DESCRIPTION
## Summary

Three targeted fixes that unblock the full devnet user-flow matrix end-to-end. All changes are isolated to devnet code paths (or gated by a `network === 'devnet'` ternary) — production code paths are unchanged.

### 1. RPC routing for devnet sends
- `app/wallet/components/SendModal.tsx`: BTC send was querying \`/api/rpc/devnet\` which can't reach the in-browser harness, so \`Available: 0 BTC\` was displayed even with a funded wallet.
- \`lib/alkanes/buildAlkaneTransferPsbt.ts\`: alkane sends were falling through to mainnet RPC because \`devnet\` was missing from the network map, surfacing as \"No UTXOs found containing alkane\".
- Both now point devnet at \`http://localhost:18888\` so the qubitcoin fetch interceptor catches them.

### 2. \`sendrawtransactions\` translator (boot.ts)
The SDK's presign-RBF path (used by every commit/reveal envelope deploy — FIRE Bonding, FIRE Token, etc.) calls Bitcoin Core's batch \`sendrawtransactions\` (plural). The qubitcoin harness only supports \`sendrawtransaction\` (singular). Without this, the boot fails partway through Phase 3 with:
\`\`\`
Bitcoin method not supported in devnet: sendrawtransactions
\`\`\`
Fix wraps \`globalThis.fetch\` to translate batch calls into N sequential singular calls. The translation is invisible to anything outside devnet — production Bitcoin Core supports both forms natively, so the txs we sign are byte-identical to what production would broadcast.

### 3. \`protect_taproot: false\` for taproot-only fundings (boot.ts)
Late-boot calls (Universal Router init, etc.) pass \`from_addresses: [taproot]\` to avoid an O(n²) hang in the WASM PSBT builder when segwit has 300+ UTXOs. But the SDK's default \`protect_taproot=true\` then excludes taproot UTXOs from fee selection, leaving zero candidates and:
\`\`\`
Insufficient funds: need 100606 sats, have 0 (selected=0, protect_taproot=true, alkanes_needed=false)
\`\`\`
Fix opts out of the protection only when fromAddresses is explicitly taproot-only.

## Test plan

Verified end-to-end on a fresh full boot (height 540, AMM pool 2:3 created with DIESEL/frBTC reserves):

- [x] Flow 1 — Wrap BTC→frBTC: tx mined, frBTC balance increased
- [x] Flow 2 — Unwrap frBTC→BTC: tx mined, BTC returned
- [x] Flow 3 — Swap DIESEL→frBTC: pool reserves moved as expected (5 DIESEL added, 0.000172 frBTC removed)
- [x] Flow 4 — Send BTC: \`Available: 13025 BTC\` displayed correctly, tx mined
- [x] Flow 5 — Send Alkane DIESEL: tx mined with two-protostone pattern intact
- [x] Audit: every flow consumes exactly the alkane UTXOs it intends to (DIESEL for swap/send-alkane, frBTC for unwrap), plus a clean BTC UTXO for fees. No collateral alkane UTXOs destroyed.
- [x] \`npx tsc --noEmit\` passes

Note: a transient regression observed where the first wrap/unwrap/swap attempt right after a fresh boot returns a phantom txid (SDK reports success but tx never mines, with \`useRouterQuote\` console errors showing \`balance underflow ... balance(0)\`). Retry works. Likely a router-state warm-up issue; not blocking and worth investigating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)