### PR TITLE
fix(keystore): BIP-341 y-parity tweak + payment_utxos for single-address taproot

### DIFF
--- a/app/wallet/components/SendModal.tsx
+++ b/app/wallet/components/SendModal.tsx
@@ -1167,6 +1167,13 @@ export default function SendModal({ isOpen, onClose, initialAlkane, onSuccess }:
       const isBrowserWallet = walletType === 'browser';
 
       // Sign the PSBT
+      // JOURNAL (2026-04-30): Keystore taproot signing must apply the BIP-341
+      // tweak with proper y-parity handling (negate privKey if internal pubkey
+      // has odd y). bip32's .tweak() ignored this and silently produced a
+      // tweaked pubkey that didn't match the witnessUtxo output key 50% of
+      // the time, causing finalizeAllInputs to throw "No tapleaf script
+      // signature provided". signTaprootPsbt now does the parity check
+      // correctly via privateNegate + ecc.privateAdd.
       let signedPsbtBase64: string;
       if (isBrowserWallet) {
         console.log('[SendModal] Browser wallet: signing all inputs in single call...');

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -1754,7 +1754,20 @@ export function WalletProvider({ children, network }: WalletProviderProps) {
     if (!wallet) {
       throw new Error('Wallet not connected');
     }
-    return wallet.signPsbt(psbtBase64);
+    // JOURNAL (2026-04-30): The wallet shim's signPsbt returns the SDK result's
+    // psbtHex (createWalletViaClient line 95). Callers expect base64 (SendModal
+    // and the mutation hooks all do `bitcoin.Psbt.fromBase64(...)`). Convert to
+    // base64 here so the public signPsbt contract is consistent (browser path
+    // already returns base64 above).
+    const signed = await wallet.signPsbt(psbtBase64);
+    // Heuristic: hex strings have only [0-9a-f]; base64 has /+= and uppercase.
+    // bitcoinjs PSBT magic = 0x70736274ff → first byte 'p' = 0x70 in base64
+    // begins with 'cHNidP...' (the standard base64 prefix). If signed starts
+    // with 'cHNidP', it's already base64 — pass through. Otherwise treat as hex.
+    if (typeof signed === 'string' && signed.startsWith('cHNidP')) {
+      return signed;
+    }
+    return Buffer.from(signed, 'hex').toString('base64');
   }, [wallet, walletAdapter, walletType, browserWalletAddresses, browserWallet]);
 
   // Sign PSBT with taproot inputs (BIP86 derivation)
@@ -1989,10 +2002,34 @@ export function WalletProvider({ children, network }: WalletProviderProps) {
     // X-only pubkey for taproot (remove first byte which is the prefix)
     const xOnlyPubkey = taprootChild.publicKey.slice(1, 33);
 
-    // Tweak the key for taproot key-path spend
-    const tweakedChild = taprootChild.tweak(
-      bitcoin.crypto.taggedHash('TapTweak', xOnlyPubkey)
-    );
+    // JOURNAL (2026-04-30): BIP-341 key-path tweak — must be applied to the
+    // private key (not via bip32.tweak()) AND the privKey must be negated
+    // first if the internal pubkey has odd y-parity. bip32's .tweak() doesn't
+    // handle the parity flip, which causes the resulting tweaked pubkey to
+    // mismatch the on-chain output key for ~50% of all keys (Y-coordinate
+    // ambiguity). bitcoinjs's _signTaprootInput then can't write tapKeySig
+    // because pubkey != outputKey, so the input is left unfinalized and
+    // finalizeAllInputs() throws "No tapleaf script signature provided".
+    //
+    // The fix: if the compressed pubkey has prefix 0x03 (odd y), negate the
+    // privKey before applying the TapTweak. This matches what
+    // ECPair.fromPrivateKey + tweakedKeyPair.signSchnorr does inside the SDK
+    // canonical path, but we apply it correctly here.
+    const ecc = await import('@bitcoinerlab/secp256k1');
+    const ecpairModule = await import('ecpair');
+    const ECPair = ecpairModule.ECPairFactory(ecc as any);
+
+    let privKeyForTweak = taprootChild.privateKey;
+    if (taprootChild.publicKey[0] === 0x03) {
+      // Odd y-parity → negate privKey so the implicit pubkey has even y
+      privKeyForTweak = ecc.privateNegate(privKeyForTweak);
+    }
+    const tapTweak = bitcoin.crypto.taggedHash('TapTweak', xOnlyPubkey);
+    const tweakedPriv = ecc.privateAdd(privKeyForTweak, tapTweak);
+    if (!tweakedPriv) {
+      throw new Error('TapTweak produced an invalid private key (overflow)');
+    }
+    const tweakedKeyPair = ECPair.fromPrivateKey(Buffer.from(tweakedPriv), { network: btcNetwork });
 
     // Parse and sign the PSBT
     const psbt = bitcoin.Psbt.fromBase64(psbtBase64, { network: btcNetwork });
@@ -2000,11 +2037,12 @@ export function WalletProvider({ children, network }: WalletProviderProps) {
     console.log('[signTaprootPsbt] Signing', psbt.inputCount, 'inputs with taproot key');
     console.log('[signTaprootPsbt] Taproot path:', taprootPath);
     console.log('[signTaprootPsbt] X-only pubkey:', Buffer.from(xOnlyPubkey).toString('hex'));
+    console.log('[signTaprootPsbt] Internal y-parity:', taprootChild.publicKey[0] === 0x03 ? 'odd (negated)' : 'even');
 
     // Sign each input with the tweaked taproot key
     for (let i = 0; i < psbt.inputCount; i++) {
       try {
-        psbt.signInput(i, tweakedChild);
+        psbt.signInput(i, tweakedKeyPair);
         console.log(`[signTaprootPsbt] Signed input ${i}`);
       } catch (error) {
         console.warn(`[signTaprootPsbt] Could not sign input ${i}:`, error);

--- a/hooks/useUnwrapMutation.ts
+++ b/hooks/useUnwrapMutation.ts
@@ -83,7 +83,7 @@ export type UnwrapTransactionBaseData = {
 };
 
 export function useUnwrapMutation() {
-  const { account, network, isConnected, signSegwitPsbt, signTaprootPsbt, walletType, browserWallet } = useWallet();
+  const { account, network, isConnected, signSegwitPsbt, signTaprootPsbt, signPsbt, walletType, browserWallet } = useWallet();
   const provider = useSandshrewProvider();
   const queryClient = useQueryClient();
   const { requestConfirmation } = useTransactionConfirm();
@@ -214,17 +214,65 @@ export function useUnwrapMutation() {
       console.log('[useUnwrapMutation] To addresses (v0=alkanes-refund, v1=btc-recipient, v2=signer-dust):', toAddresses);
       console.log('[useUnwrapMutation] Change address:', changeAddr);
 
+      // JOURNAL (2026-04-30): Single-address keystore wallets (no segwit) hit
+      // the SDK's protect_taproot=true default, which refuses to use any
+      // taproot UTXO for fees → "Insufficient funds: have 0". Pre-filter the
+      // taproot UTXO set ourselves (excluding alkane-bearing outpoints via the
+      // protorunes index) and pass the clean ones as payment_utxos. With
+      // payment_utxos set, the SDK uses only those for fees, so
+      // protect_taproot becomes a no-op. Fail-closed: if discovery fails,
+      // fall through to default behavior.
+      const isKeystoreSingleAddress = !isBrowserWallet && !!taprootAddress && !segwitAddress;
+      let paymentUtxos: string[] | undefined;
+      if (isKeystoreSingleAddress) {
+        const { getCleanTaprootBtcUtxos } = await import('@/lib/wallet/taprootCleanUtxos');
+        const clean = await getCleanTaprootBtcUtxos(taprootAddress!, network);
+        if (clean) {
+          paymentUtxos = clean;
+          console.log('[useUnwrapMutation] Single-address keystore: passing', clean.length, 'clean BTC UTXOs as payment_utxos');
+        } else {
+          console.warn('[useUnwrapMutation] Single-address keystore: clean UTXO discovery failed, SDK will likely error with protect_taproot');
+        }
+      }
 
-      const result = await provider.alkanesExecuteTyped({
-        toAddresses,
-        inputRequirements,
-        protostones: protostone,
-        feeRate: unwrapData.feeRate,
-        autoConfirm: false,
-        fromAddresses,
-        changeAddress: changeAddr,
-        alkanesChangeAddress: alkanesChangeAddr,
-      });
+      // The SDK's alkanesExecuteTyped wrapper drops protect_taproot and
+      // payment_utxos before forwarding. Build the options JSON ourselves and
+      // call alkanesExecuteFull directly when we need those flags.
+      const useDirectExecuteFull = isKeystoreSingleAddress && paymentUtxos;
+      let result: any;
+      if (useDirectExecuteFull) {
+        const options: any = {
+          from_addresses: fromAddresses,
+          change_address: changeAddr,
+          alkanes_change_address: alkanesChangeAddr,
+          // Keystore has the mnemonic loaded — auto_confirm: true matches the
+          // pattern used by every other mutation hook (e.g. useSwapMutation
+          // line 419). Without it, the WASM SDK throws "cancelled by user".
+          auto_confirm: true,
+          protect_taproot: false,
+          payment_utxos: paymentUtxos,
+        };
+        const raw = await provider.alkanesExecuteFull(
+          JSON.stringify(toAddresses),
+          inputRequirements,
+          protostone,
+          unwrapData.feeRate ?? null,
+          null,
+          JSON.stringify(options),
+        );
+        result = typeof raw === 'string' ? JSON.parse(raw) : raw;
+      } else {
+        result = await provider.alkanesExecuteTyped({
+          toAddresses,
+          inputRequirements,
+          protostones: protostone,
+          feeRate: unwrapData.feeRate,
+          autoConfirm: false,
+          fromAddresses,
+          changeAddress: changeAddr,
+          alkanesChangeAddress: alkanesChangeAddr,
+        });
+      }
 
       console.log('[useUnwrapMutation] Called alkanesExecuteTyped (browser:', isBrowserWallet, ')');
 
@@ -310,9 +358,12 @@ export function useUnwrapMutation() {
           console.log('[useUnwrapMutation] Browser wallet: signing PSBT once (all input types)...');
           signedPsbtBase64 = await signTaprootPsbt(finalPsbtBase64);
         } else {
-          console.log('[useUnwrapMutation] Keystore: signing PSBT with SegWit, then Taproot...');
-          signedPsbtBase64 = await signSegwitPsbt(finalPsbtBase64);
-          signedPsbtBase64 = await signTaprootPsbt(signedPsbtBase64);
+          // JOURNAL (2026-04-30): keystore signs via SDK signPsbt (canonical
+          // BIP-341 tweak via ecc.privateAdd). The old signSegwit+signTaproot
+          // pair used bip32 .tweak() which y-flips half the time and silently
+          // skips tapKeySig, breaking finalize on mixed P2WPKH+P2TR PSBTs.
+          console.log('[useUnwrapMutation] Keystore: signing PSBT via SDK signPsbt...');
+          signedPsbtBase64 = await signPsbt(finalPsbtBase64);
         }
 
         // Finalize and extract transaction. Some wallets (UniSat with

--- a/lib/wallet/taprootCleanUtxos.ts
+++ b/lib/wallet/taprootCleanUtxos.ts
@@ -1,0 +1,153 @@
+/**
+ * Clean BTC UTXO discovery for keystore single-address (taproot-only) wallets.
+ *
+ * Why this exists:
+ *   The SDK's default `protect_taproot=true` excludes ALL taproot UTXOs from
+ *   fee-input selection because it can't tell which carry alkanes. For dual-
+ *   address wallets (keystore with both segwit and taproot, or browser wallets
+ *   like Xverse) this is fine — fees come from segwit. But for single-address
+ *   keystores (the boot wallet, or a user who only has a taproot address) the
+ *   protection becomes a denial-of-service: zero fee candidates → "Insufficient
+ *   funds: have 0 (protect_taproot=true)".
+ *
+ *   This helper does what `protect_taproot` was protecting us from at the SDK
+ *   layer — explicitly enumerate the BTC-only taproot UTXOs (subtracting any
+ *   that the alkanes indexer says carry tokens) and hand them back as a list
+ *   the SDK can use directly via `payment_utxos`.
+ *
+ *   When `payment_utxos` is set in the SDK options, the SDK uses ONLY those
+ *   UTXOs for fees and never falls back to discovery — so `protect_taproot`
+ *   becomes a no-op. We've answered its question for it.
+ *
+ * Fail-closed: if either the UTXO list or the alkane-outpoint query fails,
+ * we return null and the caller should NOT pass `payment_utxos` (let the SDK
+ * take its default behavior, which will fail loudly rather than silently
+ * spending an alkane UTXO as fee).
+ */
+
+const RPC_ENDPOINTS: Record<string, string> = {
+  mainnet: 'https://mainnet.subfrost.io/v4/subfrost',
+  testnet: 'https://testnet.subfrost.io/v4/subfrost',
+  signet: 'https://signet.subfrost.io/v4/subfrost',
+  regtest: 'https://regtest.subfrost.io/v4/subfrost',
+  'regtest-local': 'http://localhost:18888',
+  devnet: 'http://localhost:18888',
+  'subfrost-regtest': 'https://regtest.subfrost.io/v4/subfrost',
+  oylnet: 'https://regtest.subfrost.io/v4/subfrost',
+};
+
+interface SimpleUtxo {
+  txid: string;
+  vout: number;
+  value: number;
+  confirmed: boolean;
+}
+
+async function fetchAddressUtxos(address: string, networkName?: string): Promise<SimpleUtxo[]> {
+  const rpcUrl = networkName === 'devnet' ? 'http://localhost:18888' : '/api/rpc';
+  const resp = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'esplora_address::utxo',
+      params: [address],
+      id: 1,
+    }),
+  });
+  const json = await resp.json();
+
+  if (networkName === 'devnet') {
+    const utxos = (Array.isArray(json.result) ? json.result : []).map((u: any) => ({
+      txid: u.txid,
+      vout: u.vout,
+      value: u.value,
+      confirmed: u.status?.confirmed ?? false,
+    }));
+    return utxos;
+  }
+
+  if (!json.result || !Array.isArray(json.result) || json.result.length === 0) {
+    const restUrl = `/api/esplora/address/${address}/utxo${networkName ? `?network=${networkName}` : ''}`;
+    const restResp = await fetch(restUrl);
+    if (!restResp.ok) throw new Error(`esplora REST returned ${restResp.status}`);
+    const restJson = await restResp.json();
+    if (!Array.isArray(restJson)) throw new Error('esplora REST returned non-array');
+    return restJson.map((u: any) => ({
+      txid: u.txid,
+      vout: u.vout,
+      value: u.value,
+      confirmed: u.status?.confirmed ?? false,
+    }));
+  }
+
+  return json.result.map((u: any) => ({
+    txid: u.txid,
+    vout: u.vout,
+    value: u.value,
+    confirmed: u.status?.confirmed ?? false,
+  }));
+}
+
+async function fetchAlkaneOutpointKeys(address: string, networkName?: string): Promise<Set<string>> {
+  const baseUrl = RPC_ENDPOINTS[networkName || 'mainnet'] || RPC_ENDPOINTS.mainnet;
+  const resp = await fetch(baseUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'alkanes_protorunesbyaddress',
+      params: [{ address, protocolTag: '1' }],
+    }),
+  });
+  const json = await resp.json();
+  if (json.error) throw new Error(json.error.message || 'protorunesbyaddress RPC error');
+
+  const outpoints = json?.result?.outpoints || [];
+  const keys = new Set<string>();
+  for (const entry of outpoints) {
+    const op = entry.outpoint;
+    if (!op || typeof op !== 'object') continue;
+    const txid = op.txid;
+    const vout = op.vout;
+    if (!txid || typeof vout !== 'number') continue;
+    // Only mark as alkane-bearing if the balance sheet has at least one non-zero entry
+    const balances = entry?.balance_sheet?.cached?.balances || [];
+    const hasNonZero = balances.some((b: any) => b.amount && BigInt(b.amount) > 0n);
+    if (hasNonZero) keys.add(`${txid}:${vout}`);
+  }
+  return keys;
+}
+
+/**
+ * Returns clean BTC-only UTXOs at a single taproot address as `txid:vout:satoshis`
+ * strings (the format `payment_utxos` expects in the SDK options). Returns null
+ * on any error — caller should fall through to default SDK behavior.
+ *
+ * Filters applied:
+ *   - confirmed only (mempool selection is the SDK's job)
+ *   - excludes any outpoint the alkanes indexer reports as carrying tokens
+ *   - excludes dust < 600 sats (can't be a useful fee input)
+ */
+export async function getCleanTaprootBtcUtxos(
+  taprootAddress: string,
+  networkName?: string,
+): Promise<string[] | null> {
+  if (!taprootAddress) return null;
+  try {
+    const [allUtxos, alkaneKeys] = await Promise.all([
+      fetchAddressUtxos(taprootAddress, networkName),
+      fetchAlkaneOutpointKeys(taprootAddress, networkName),
+    ]);
+    const clean = allUtxos
+      .filter(u => u.confirmed)
+      .filter(u => u.value >= 600)
+      .filter(u => !alkaneKeys.has(`${u.txid}:${u.vout}`))
+      .map(u => `${u.txid}:${u.vout}:${u.value}`);
+    return clean.length > 0 ? clean : null;
+  } catch (e) {
+    console.warn('[getCleanTaprootBtcUtxos] Failed, falling back to SDK default:', (e as Error)?.message);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Two bugs that surface when running the user-flow matrix on a keystore wallet whose only address is taproot (the boot wallet, or a user keystore where segwit isn't exposed). Both were masked on dual-address wallets and only became visible during this session's matrix testing.

### Bug 1 — \`signTaprootPsbt\` y-parity ([context/WalletContext.tsx](context/WalletContext.tsx))

bip32's \`.tweak()\` ignores BIP-340 y-parity. Per BIP-341 the tweak must be applied to the parity-corrected private key (negate when internal pubkey has odd y), or the resulting tweaked public key won't match the on-chain output key for ~50% of all keys.

When that happens, bitcoinjs's \`_signTaprootInput\` silently writes nothing because \`toXOnly(tweakedPubkey) !== witnessUtxo.script[2..34]\`. The input has no \`tapKeySig\`. \`finalizeAllInputs()\` falls through to script-path finalization and throws *"No tapleaf script signature provided"*.

Fix: explicit \`privateNegate\` when \`taprootChild.publicKey[0] === 0x03\`, then \`ecc.privateAdd\` for the canonical BIP-341 tweak. Sign with the tweaked privkey via \`ECPair.fromPrivateKey\`.

Also fixes \`signPsbt\` to convert the wallet shim's hex output to base64, since callers all do \`Psbt.fromBase64(...)\` and would otherwise crash with *"Invalid Magic Number"*.

### Bug 2 — \`protect_taproot\` deadlock for single-address keystore ([hooks/useUnwrapMutation.ts](hooks/useUnwrapMutation.ts) + [lib/wallet/taprootCleanUtxos.ts](lib/wallet/taprootCleanUtxos.ts))

The SDK's default \`protect_taproot=true\` excludes ALL taproot UTXOs from fee selection. Dual-address wallets are fine (fees come from segwit). Single-address keystore wallets where taproot is the ONLY fee source hit *"Insufficient funds: have 0 (protect_taproot=true, alkanes_needed=true)"*.

Unwrap is the most-affected flow because its \`inputRequirements\` is purely the alkane — no anchor for separate BTC fees.

Fix: query the taproot UTXOs and \`alkanes_protorunesbyaddress\` index, subtract alkane-bearing outpoints, pass clean ones as \`payment_utxos\` to \`alkanesExecuteFull\` directly (the \`alkanesExecuteTyped\` wrapper silently drops \`payment_utxos\`/\`protect_taproot\`). With explicit \`payment_utxos\`, \`protect_taproot\` becomes a no-op — we've answered its question for it.

**Fail-closed**: if either query fails, fall through to default SDK behavior. The SDK errors loudly rather than silently spending an alkane UTXO as fee.

## Test plan

Full user-flow matrix on a fresh keystore single-address (boot taproot) wallet:
- [x] Wrap BTC→frBTC: \`f68dce81…d466\` (block 1296)
- [x] **Unwrap frBTC→BTC: \`a56fb707…5314\` (block 888)** — payment_utxos fix
- [x] Swap DIESEL→frBTC: \`a6e1fa99…c0f4\` (block 1298)
- [x] Send BTC: \`68d04fcc…5501\` (block 1300)
- [x] **Send Alkane DIESEL: \`8e3d75f7…1743\` (block 1193)** — y-parity fix
- [x] \`pnpm test:unit\` — 1925 tests pass, 0 failures

## Follow-up

The \`payment_utxos\` pattern in \`useUnwrapMutation\` is general-purpose. Other mutation hooks (\`useSwap\`/\`useWrap\`/\`useAddLiquidity\`/\`useRemoveLiquidity\`/SDK-path send-alkane) happen to dodge the deadlock today because their \`inputRequirements\` includes \`B:N\` which anchors fee discovery elsewhere. If a future flow surfaces the same blocker, the fix is mechanical: copy the 15-line pattern from \`useUnwrapMutation\`. Tracking as a follow-up rather than speculatively expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)