### PR TITLE
fix(balances): keep alkane balances visible during HeightPoller refetch

### DIFF
--- a/hooks/__tests__/useEnrichedWalletData.test.ts
+++ b/hooks/__tests__/useEnrichedWalletData.test.ts
@@ -682,7 +682,7 @@ describe('Cross-cutting: error handling patterns', () => {
 describe('Cross-cutting: React Query caching', () => {
   it('useEnrichedWalletData uses queryOptions from @tanstack/react-query', () => {
     const querySrc = readSrc('queries/account.ts');
-    expect(querySrc).toContain("import { queryOptions } from '@tanstack/react-query'");
+    expect(querySrc).toMatch(/import\s*{[^}]*\bqueryOptions\b[^}]*}\s*from\s*['"]@tanstack\/react-query['"]/);
   });
 
   it('useTransactionHistory uses useInfiniteQuery from @tanstack/react-query', () => {

--- a/queries/account.ts
+++ b/queries/account.ts
@@ -14,7 +14,7 @@
  * Changed to check both: `result.alkanes || result.data` and `entry.amount || entry.balance`.
  */
 
-import { queryOptions } from '@tanstack/react-query';
+import { queryOptions, keepPreviousData } from '@tanstack/react-query';
 import { queryKeys } from './keys';
 import { KNOWN_TOKENS } from '@/lib/alkanes-client';
 import { getRpcUrl } from '@/utils/getConfig';
@@ -707,6 +707,11 @@ export function alkaneBalanceQueryOptions(deps: AlkaneBalanceDeps) {
     refetchOnMount: true,
     refetchOnWindowFocus: false,
     refetchInterval: (deps.network === 'devnet' || deps.network === 'regtest-local' || deps.network === 'qubitcoin-regtest') ? 5_000 : undefined,
+    // Keep the previous fetch's data visible while a refetch is in flight.
+    // Without this, HeightPoller invalidation (every block) sets data to undefined
+    // mid-refetch, the consumer falls through to `?? []`, and balances visibly
+    // disappear and reappear once per block.
+    placeholderData: keepPreviousData,
     retry: 3,
     retryDelay: (attempt: number) => Math.min(1000 * 2 ** attempt, 10000),
     queryFn: async () => {


### PR DESCRIPTION
## Summary
- Adds `placeholderData: keepPreviousData` to `alkaneBalanceQueryOptions` so balances no longer disappear/reappear once per block when HeightPoller invalidates the query
- The consumer (`useEnrichedWalletData`) falls through to `?? []` when `data` is undefined; without `placeholderData`, every refetch left the UI showing "no alkanes" until the new fetch landed
- BTC fast balance was unaffected because it already sets `placeholderData: cached` — this fix brings alkane balances to parity
- Loosens one brittle source-analysis test that asserted the exact import line; the regex preserves the test's intent ("imports `queryOptions` from `@tanstack/react-query`") without locking the rest of the import statement

## Why this is a pragmatic fix
Discussed in chat: a more elegant design would express balance freshness explicitly (a `BalanceSnapshot` with `asOfHeight` + `freshness` states, optimistic updates after mutations, soft "verifying" UI affordance, surgical `markStaleAndRefetch` instead of carpet invalidation in HeightPoller). That's the right long-term shape but it's a 200–500 LOC architectural change. This PR is the one-line config that kills 90% of the user-visible flicker today.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run hooks/__tests__/useEnrichedWalletData.test.ts` — 6 pre-existing `useDemoGate` failures (present on parent `bdae22a7`, unrelated), 0 new failures introduced by this PR
- [ ] Manual: load `/wallet` on staging, watch for one block to land, confirm alkane balances no longer flicker
- [ ] Manual: hit `/swap` after a wrap/swap completes, confirm balance updates without a flicker between invalidation and refetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)