### PR TITLE
feat(explorer): network-aware tx explorer URLs via getTxExplorerUrl helper

### DIFF
--- a/app/components/ActivityFeed.tsx
+++ b/app/components/ActivityFeed.tsx
@@ -12,6 +12,7 @@ import TokenIcon from "@/app/components/TokenIcon";
 import Link from "next/link";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useWallet } from "@/context/WalletContext";
+import { getTxExplorerUrl } from "@/utils/getConfig";
 
 type AmmRow =
   | {
@@ -498,15 +499,16 @@ export default function ActivityFeed({
               nameResolved(pairNames.leftId) &&
               nameResolved(pairNames.rightId);
 
-            const txExplorerHref = network === 'devnet' || network === 'regtest' || network === 'regtest-local'
-              ? '#' // No block explorer for devnet/regtest
-              : `https://espo.sh/tx/${(row as any).transactionId}`;
+            const txExplorerHref = getTxExplorerUrl(network, (row as any).transactionId);
+            const RowEl: any = txExplorerHref ? Link : 'div';
+            const rowProps: any = txExplorerHref
+              ? { href: txExplorerHref, target: '_blank', rel: 'noopener noreferrer' }
+              : {};
 
             return (
-              <Link
+              <RowEl
                 key={(row as any).transactionId + "-" + idx}
-                href={txExplorerHref}
-                target={txExplorerHref === '#' ? undefined : '_blank'}
+                {...rowProps}
                 className="block px-6 py-2 text-[11px] leading-[20px] transition-all duration-[400ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none hover:bg-[color:var(--sf-primary)]/10 border-b border-[color:var(--sf-row-border)]"
               >
                 {/* Mobile layout (xs only) - 2 rows */}
@@ -804,7 +806,7 @@ export default function ActivityFeed({
                     <span className="hidden lg:inline">{timeLabel}</span>
                   </div>
                 </div>
-              </Link>
+              </RowEl>
             );
           })}
           {(isLoading || isFetchingNextPage) && (

--- a/app/components/SwapSuccessNotification.tsx
+++ b/app/components/SwapSuccessNotification.tsx
@@ -5,6 +5,8 @@ import { Minus, Send } from "lucide-react";
 import Link from "next/link";
 import { useTranslation } from '@/hooks/useTranslation';
 import { useTxConfirmed } from '@/hooks/useTxConfirmed';
+import { useWallet } from '@/context/WalletContext';
+import { getTxExplorerUrl } from '@/utils/getConfig';
 
 export type OperationType = 'swap' | 'wrap' | 'unwrap' | 'addLiquidity' | 'removeLiquidity' | 'send';
 
@@ -27,12 +29,14 @@ export default function SwapSuccessNotification({
   stepContext,
 }: Props) {
   const { t } = useTranslation();
+  const { network } = useWallet() as any;
   const [isFlashing, setIsFlashing] = useState(true);
   const [isVisible, setIsVisible] = useState(false);
   const [isExpanded, setIsExpanded] = useState(true);
   const autoCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const confirmed = useTxConfirmed(autoCloseAfterConfirmed ? txId : undefined);
+  const txExplorerHref = getTxExplorerUrl(network, txId);
 
   const OPERATION_LABELS: Record<OperationType, string> = {
     swap: t('success.swap'),
@@ -140,13 +144,17 @@ export default function SwapSuccessNotification({
             </h3>
             <div className="text-sm text-[color:var(--sf-info-green-text)]">
               {t('success.transactionId')}{" "}
-              <Link
-                href={`https://espo.sh/tx/${txId}`}
-                target="_blank"
-                className="font-semibold text-xs break-all hover:underline"
-              >
-                {txId}
-              </Link>
+              {txExplorerHref ? (
+                <Link
+                  href={txExplorerHref}
+                  target="_blank"
+                  className="font-semibold text-xs break-all hover:underline"
+                >
+                  {txId}
+                </Link>
+              ) : (
+                <span className="font-semibold text-xs break-all">{txId}</span>
+              )}
             </div>
           </div>
 

--- a/app/swap/components/MyWalletSwaps.tsx
+++ b/app/swap/components/MyWalletSwaps.tsx
@@ -8,6 +8,7 @@ import TokenIcon from '@/app/components/TokenIcon';
 import Link from 'next/link';
 import { useWallet } from '@/context/WalletContext';
 import { useTranslation } from '@/hooks/useTranslation';
+import { getTxExplorerUrl } from '@/utils/getConfig';
 import type { Network } from '@/utils/constants';
 
 type AmmRow =
@@ -221,12 +222,17 @@ export default function MyWalletSwaps() {
                     }
                   })();
 
+                  const txExplorerUrl = getTxExplorerUrl(network, (row as any).transactionId);
+
+                  const RowEl: any = txExplorerUrl ? Link : 'div';
+                  const rowProps: any = txExplorerUrl
+                    ? { href: txExplorerUrl, target: '_blank', rel: 'noopener noreferrer' }
+                    : {};
+
                   return (
-                    <Link
+                    <RowEl
                       key={(row as any).transactionId + '-' + idx}
-                      href={`https://espo.sh/tx/${(row as any).transactionId}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      {...rowProps}
                       className="sf-row block"
                     >
                       <div className="grid grid-cols-[0.5fr_0.7fr_0.7fr_1fr_0.6fr] gap-1 text-[11px] leading-[20px] px-4 py-1.5 items-center">
@@ -257,7 +263,7 @@ export default function MyWalletSwaps() {
                           {timeLabel}
                         </span>
                       </div>
-                    </Link>
+                    </RowEl>
                   );
                 })}
               </>

--- a/app/wallet/__tests__/wallet-dashboard.test.ts
+++ b/app/wallet/__tests__/wallet-dashboard.test.ts
@@ -360,8 +360,8 @@ describe('TransactionHistory', () => {
     expect(src).toMatch(/t\(['"]txHistory\.noActivity['"]\)/);
   });
 
-  it('links transactions to espo.sh explorer', () => {
-    expect(src).toMatch(/espo\.sh\/tx/);
+  it('links transactions to network-aware explorer via getTxExplorerUrl', () => {
+    expect(src).toMatch(/getTxExplorerUrl\(network,\s*tx\.txid\)/);
   });
 
   it('shows alkanes badge for transactions with protostones', () => {

--- a/app/wallet/components/SendModal.tsx
+++ b/app/wallet/components/SendModal.tsx
@@ -109,6 +109,7 @@ import { useNotification } from '@/context/NotificationContext';
 import { useEnrichedWalletData } from '@/hooks/useEnrichedWalletData';
 import { useSandshrewProvider } from '@/hooks/useSandshrewProvider';
 import TokenIcon from '@/app/components/TokenIcon';
+import { getTxExplorerUrl } from '@/utils/getConfig';
 import { useFeeRate, FeeSelection } from '@/hooks/useFeeRate';
 import { usePools } from '@/hooks/usePools';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -1391,22 +1392,26 @@ export default function SendModal({ isOpen, onClose, initialAlkane, onSuccess }:
     </div>
   );
 
-  const renderSuccess = () => (
+  const renderSuccess = () => {
+    const successTxUrl = txid ? getTxExplorerUrl(network, txid) : null;
+    const SuccessTxEl: any = successTxUrl ? 'a' : 'div';
+    const successTxProps: any = successTxUrl
+      ? { href: successTxUrl, target: '_blank', rel: 'noopener noreferrer' }
+      : {};
+    return (
     <>
       <div className="flex flex-col items-center justify-center py-8 space-y-4">
         <CheckCircle size={64} className="text-green-400" />
         <div className="text-xl font-bold text-[color:var(--sf-text)]">{t('send.transactionSent')}</div>
 
-        <a
-          href={`https://espo.sh/tx/${txid}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="w-full rounded-lg bg-[color:var(--sf-info-green-bg)] border border-[color:var(--sf-info-green-border)] p-3 hover:brightness-110 transition-all duration-[200ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none cursor-pointer relative"
+        <SuccessTxEl
+          {...successTxProps}
+          className={`w-full rounded-lg bg-[color:var(--sf-info-green-bg)] border border-[color:var(--sf-info-green-border)] p-3 transition-all duration-[200ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none relative ${successTxUrl ? 'hover:brightness-110 cursor-pointer' : ''}`}
         >
-          <ExternalLink size={12} className="absolute top-3 right-3 text-[color:var(--sf-info-green-text)]/60" />
+          {successTxUrl && <ExternalLink size={12} className="absolute top-3 right-3 text-[color:var(--sf-info-green-text)]/60" />}
           <div className="text-xs text-[color:var(--sf-info-green-title)] mb-1">{t('send.transactionIdLabel')}</div>
-          <div data-testid="txid" className="text-sm text-[color:var(--sf-info-green-text)] break-all pr-6">{txid}</div>
-        </a>
+          <div data-testid="txid" className={`text-sm text-[color:var(--sf-info-green-text)] break-all ${successTxUrl ? 'pr-6' : ''}`}>{txid}</div>
+        </SuccessTxEl>
       </div>
 
       <button
@@ -1416,7 +1421,8 @@ export default function SendModal({ isOpen, onClose, initialAlkane, onSuccess }:
         {t('send.close')}
       </button>
     </>
-  );
+    );
+  };
 
   return (
     <div className="sf-popup-overlay p-4" onClick={onClose}>

--- a/app/wallet/components/TransactionHistory.tsx
+++ b/app/wallet/components/TransactionHistory.tsx
@@ -5,6 +5,7 @@ import { useWallet } from '@/context/WalletContext';
 import { useTransactionHistory } from '@/hooks/useTransactionHistory';
 import { RefreshCw, Zap, Loader2 } from 'lucide-react';
 import { useTranslation } from '@/hooks/useTranslation';
+import { getTxExplorerUrl } from '@/utils/getConfig';
 
 export interface TransactionHistoryHandle {
   refresh: () => Promise<void>;
@@ -12,7 +13,7 @@ export interface TransactionHistoryHandle {
 }
 
 const TransactionHistory = forwardRef<TransactionHistoryHandle>(function TransactionHistory(_props, ref) {
-  const { account } = useWallet() as any;
+  const { account, network } = useWallet() as any;
   const { t } = useTranslation();
 
   const addresses = [
@@ -92,13 +93,17 @@ const TransactionHistory = forwardRef<TransactionHistoryHandle>(function Transac
       <div ref={scrollRef} className="space-y-2 max-h-[308px] lg:max-h-[752px] overflow-y-auto pr-1 no-scrollbar">
         {transactions.length > 0 ? (
           <>
-            {transactions.map((tx) => (
-              <a
+            {transactions.map((tx) => {
+              const txUrl = getTxExplorerUrl(network, tx.txid);
+              const TxEl: any = txUrl ? 'a' : 'div';
+              const txProps: any = txUrl
+                ? { href: txUrl, target: '_blank', rel: 'noopener noreferrer' }
+                : {};
+              return (
+              <TxEl
                 key={tx.txid}
-                href={`https://espo.sh/tx/${tx.txid}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block rounded-lg bg-[color:var(--sf-primary)]/5 hover:bg-[color:var(--sf-primary)]/10 transition-all duration-[400ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none cursor-pointer p-3"
+                {...txProps}
+                className={`block rounded-lg bg-[color:var(--sf-primary)]/5 transition-all duration-[400ms] ease-[cubic-bezier(0,0,0,1)] hover:transition-none p-3 ${txUrl ? 'hover:bg-[color:var(--sf-primary)]/10 cursor-pointer' : ''}`}
               >
                 {/* Transaction Header */}
                 <div className="flex items-center justify-between">
@@ -130,8 +135,9 @@ const TransactionHistory = forwardRef<TransactionHistoryHandle>(function Transac
                     tx.fee ? `${t('txHistory.fee')} ${tx.fee.toLocaleString()} ${t('txHistory.sats')}` : null,
                   ].filter(Boolean).join(' • ')}
                 </div>
-              </a>
-            ))}
+              </TxEl>
+              );
+            })}
             {/* Loading more indicator */}
             {isLoadingMore && (
               <div className="flex items-center justify-center py-3">

--- a/app/wallet/components/UTXOManagement.tsx
+++ b/app/wallet/components/UTXOManagement.tsx
@@ -2,14 +2,17 @@
 
 import { useState, useEffect } from 'react';
 import { useEnrichedWalletData } from '@/hooks/useEnrichedWalletData';
+import { useWallet } from '@/context/WalletContext';
 import { Box, ChevronDown, ChevronUp, ExternalLink, Loader2, RefreshCw, Filter, Lock, Unlock, Scissors } from 'lucide-react';
 import InscriptionRenderer from '@/app/components/InscriptionRenderer';
 import SplitUtxoModal from './SplitUtxoModal';
+import { getTxExplorerUrl } from '@/utils/getConfig';
 
 type UTXOFilterType = 'all' | 'p2wpkh' | 'p2tr' | 'protorunes' | 'runes' | 'brc20';
 
 export default function UTXOManagement() {
   const { utxos, isLoading, error, refresh } = useEnrichedWalletData();
+  const { network } = useWallet() as any;
   const [expandedUtxo, setExpandedUtxo] = useState<string | null>(null);
   const [selectedFilters, setSelectedFilters] = useState<Set<UTXOFilterType>>(new Set(['all']));
   const [frozenUtxos, setFrozenUtxos] = useState<Set<string>>(new Set());
@@ -281,14 +284,19 @@ export default function UTXOManagement() {
                         <span className="text-[color:var(--sf-text)]/60">Transaction ID:</span>
                         <div className="flex items-center gap-2 mt-1">
                           <span className="text-xs break-all text-[color:var(--sf-text)]">{utxo.txid}</span>
-                          <a
-                            href={`https://espo.sh/tx/${utxo.txid}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-[color:var(--sf-primary)] hover:opacity-80"
-                          >
-                            <ExternalLink size={14} />
-                          </a>
+                          {(() => {
+                            const utxoTxUrl = getTxExplorerUrl(network, utxo.txid);
+                            return utxoTxUrl ? (
+                              <a
+                                href={utxoTxUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-[color:var(--sf-primary)] hover:opacity-80"
+                              >
+                                <ExternalLink size={14} />
+                              </a>
+                            ) : null;
+                          })()}
                         </div>
                       </div>
                       <div className="text-[color:var(--sf-text)]">

--- a/utils/__tests__/getConfig.test.ts
+++ b/utils/__tests__/getConfig.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getConfig, SUBFROST_API_URLS, BLOCK_EXPLORER_URLS } from '../getConfig';
+import { getConfig, SUBFROST_API_URLS, BLOCK_EXPLORER_URLS, getTxExplorerUrl } from '../getConfig';
 
 describe('getConfig', () => {
   // --- Factory IDs ---
@@ -143,5 +143,60 @@ describe('getConfig', () => {
   it('regtest has empty ETH explorer', () => {
     const config = getConfig('regtest');
     expect(config.BLOCK_EXPLORER_URL_ETH).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTxExplorerUrl — user-facing transaction link policy
+// ---------------------------------------------------------------------------
+describe('getTxExplorerUrl', () => {
+  const sampleTxid = 'b9b179ebc676cce55fd6892eb41159ac02cadc4a6124c65e573a9de128b3697d';
+
+  it('mainnet uses public espo.sh domain', () => {
+    expect(getTxExplorerUrl('mainnet', sampleTxid)).toBe(`https://espo.sh/tx/${sampleTxid}`);
+  });
+
+  it('regtest routes to subfrost-hosted explorer', () => {
+    expect(getTxExplorerUrl('regtest', sampleTxid)).toBe(`https://espo.subfrost.io/regtest/tx/${sampleTxid}`);
+  });
+
+  it('subfrost-regtest matches regtest', () => {
+    expect(getTxExplorerUrl('subfrost-regtest', sampleTxid)).toBe(`https://espo.subfrost.io/regtest/tx/${sampleTxid}`);
+  });
+
+  it('testnet routes to subfrost-hosted explorer', () => {
+    expect(getTxExplorerUrl('testnet', sampleTxid)).toBe(`https://espo.subfrost.io/testnet/tx/${sampleTxid}`);
+  });
+
+  it('signet routes to subfrost-hosted explorer', () => {
+    expect(getTxExplorerUrl('signet', sampleTxid)).toBe(`https://espo.subfrost.io/signet/tx/${sampleTxid}`);
+  });
+
+  it('oylnet routes to mainnet-flavored subfrost explorer', () => {
+    expect(getTxExplorerUrl('oylnet', sampleTxid)).toBe(`https://espo.subfrost.io/mainnet/tx/${sampleTxid}`);
+  });
+
+  it('devnet returns null (no public explorer)', () => {
+    expect(getTxExplorerUrl('devnet', sampleTxid)).toBeNull();
+  });
+
+  it('regtest-local returns null (no public explorer)', () => {
+    expect(getTxExplorerUrl('regtest-local', sampleTxid)).toBeNull();
+  });
+
+  it('qubitcoin-regtest returns null (no public explorer)', () => {
+    expect(getTxExplorerUrl('qubitcoin-regtest', sampleTxid)).toBeNull();
+  });
+
+  it('empty txid returns null', () => {
+    expect(getTxExplorerUrl('mainnet', '')).toBeNull();
+  });
+
+  it('undefined network falls back to mainnet (production-leaning default)', () => {
+    expect(getTxExplorerUrl(undefined, sampleTxid)).toBe(`https://espo.sh/tx/${sampleTxid}`);
+  });
+
+  it('unknown network falls back to mainnet (production-leaning default)', () => {
+    expect(getTxExplorerUrl('unknown-network', sampleTxid)).toBe(`https://espo.sh/tx/${sampleTxid}`);
   });
 });

--- a/utils/getConfig.ts
+++ b/utils/getConfig.ts
@@ -32,6 +32,24 @@ export const BLOCK_EXPLORER_URLS: Record<string, string> = {
   devnet: '', // No external block explorer for devnet
 };
 
+// User-facing transaction explorer base per network. Decoupled from
+// BLOCK_EXPLORER_URLS (which is consumed by infra/diagnostic paths) because
+// the user-facing link policy is its own concern: mainnet keeps the public
+// neutral domain (espo.sh) for the decentralization signal, while non-mainnet
+// public networks route to the subfrost-hosted explorer that's actually
+// indexing those networks. Local networks have no public link.
+const TX_EXPLORER_BASES: Record<string, string> = {
+  mainnet: 'https://espo.sh/tx',
+  testnet: 'https://espo.subfrost.io/testnet/tx',
+  signet: 'https://espo.subfrost.io/signet/tx',
+  regtest: 'https://espo.subfrost.io/regtest/tx',
+  'subfrost-regtest': 'https://espo.subfrost.io/regtest/tx',
+  oylnet: 'https://espo.subfrost.io/mainnet/tx',
+  'regtest-local': '',
+  'qubitcoin-regtest': '',
+  devnet: '',
+};
+
 /**
  * Get the RPC URL for a network. For devnet, returns the localhost URL
  * that the fetch interceptor routes to the in-process server.
@@ -40,6 +58,22 @@ export const BLOCK_EXPLORER_URLS: Record<string, string> = {
 export function getRpcUrl(network: string): string {
   if (network === 'devnet') return 'http://localhost:18888';
   return `/api/rpc/${network}`;
+}
+
+/**
+ * Get the user-facing transaction explorer URL for a given network and txid.
+ * Returns `null` when no public explorer exists (local networks). Callers
+ * should render the txid as plain text in that case rather than a dead link.
+ *
+ * Single point of control: change a network's link target here, not at every
+ * call site. Defaults to mainnet for unknown networks so production-leaning
+ * misconfigurations still produce a working link rather than a broken one.
+ */
+export function getTxExplorerUrl(network: string | undefined, txid: string): string | null {
+  if (!txid) return null;
+  const base = TX_EXPLORER_BASES[network ?? 'mainnet'] ?? TX_EXPLORER_BASES.mainnet;
+  if (!base) return null;
+  return `${base}/${txid}`;
 }
 
 export function getConfig(network: string) {


### PR DESCRIPTION
## Summary

- All wallet/swap tx links were hardcoded to `https://espo.sh/tx/${txid}` regardless of network — broken on regtest/testnet/signet, dead on local networks.
- Centralized the link policy in `getTxExplorerUrl(network, txid)` next to `getRpcUrl` in `utils/getConfig.ts`.
- Updated 6 call sites to use the helper. UI conditionally renders the link element only when a public explorer exists for that network — txid renders as plain text otherwise instead of a dead `#` href.

### Policy

| Network | Explorer base | Reason |
|---|---|---|
| mainnet | `espo.sh/tx` | Public neutral domain — preserves the decentralization-signal UX preference |
| testnet / signet / regtest / subfrost-regtest / oylnet | `espo.subfrost.io/{net}/tx` | Subfrost-hosted explorer is the one indexing those networks |
| devnet / regtest-local / qubitcoin-regtest | `null` | No public explorer — show plain txid |
| unknown / undefined | `espo.sh/tx` | Production-leaning default for misconfigurations |

Single point of control: change a network's link in `utils/getConfig.ts`, not at every call site.

### Files touched

- `utils/getConfig.ts` — `getTxExplorerUrl` helper + `TX_EXPLORER_BASES` map
- `utils/__tests__/getConfig.test.ts` — 12 new unit tests covering all networks + edge cases
- `app/components/ActivityFeed.tsx` — replaces inline ternary with helper
- `app/components/SwapSuccessNotification.tsx` — reads network via `useWallet()`
- `app/swap/components/MyWalletSwaps.tsx` — uses helper
- `app/wallet/components/SendModal.tsx` — uses helper
- `app/wallet/components/TransactionHistory.tsx` — uses helper
- `app/wallet/components/UTXOManagement.tsx` — uses helper
- `app/wallet/__tests__/wallet-dashboard.test.ts` — loosened source-analysis regex from literal URL to helper call shape

### Verification

- `npx tsc --noEmit` — clean
- 32/32 `getConfig` tests pass (20 pre-existing + 12 new)
- 202/203 affected-area tests pass; 1 unrelated pre-existing failure in `wallet/page.tsx` regex assertion (pre-existed on develop).

## Test plan

- [ ] Click a tx link in MyActivity / ActivityFeed / wallet TransactionHistory / SendModal success / SwapSuccessNotification — opens correct subfrost-hosted explorer for the active network.
- [ ] On mainnet, links still go to `espo.sh` (decentralization UX preference preserved).
- [ ] On regtest, links go to `espo.subfrost.io/regtest/tx/...` instead of `espo.sh/tx/...`.
- [ ] On devnet / regtest-local, txid renders as plain text — no broken `#` link.
- [ ] UTXOManagement detail panel: external-link icon hidden on local networks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)