### PR TITLE
fix(swap): percolate fee rate from modal to atomic flows

### DIFF
--- a/app/swap/SwapShell.tsx
+++ b/app/swap/SwapShell.tsx
@@ -1214,6 +1214,7 @@ export default function SwapShell() {
           minimumReceived: quote.minimumReceived || '1',
           maxSlippage,
           deadlineBlocks,
+          feeRate: fee.feeRate,
         });
 
         if (result?.success && result.transactionId) {
@@ -1270,6 +1271,7 @@ export default function SwapShell() {
           sellAmount: quote.sellAmount,
           buyAmount: quote.buyAmount,
           poolId: quote.poolId,
+          feeRate: fee.feeRate,
           onProgress: (p) => setSwapFlowStep(p as any),
           onNotify: (txId, op, ctx) => showNotification(txId, op, ctx),
         });
@@ -1407,6 +1409,7 @@ export default function SwapShell() {
           tokenAmount,
           maxSlippage,
           deadlineBlocks,
+          feeRate: fee.feeRate,
           poolId,
         });
         if (result?.success && result.transactionId) {

--- a/hooks/useAtomicWrapAddLiquidityMutation.ts
+++ b/hooks/useAtomicWrapAddLiquidityMutation.ts
@@ -25,7 +25,6 @@ import { useWallet } from '@/context/WalletContext';
 import { useAddLiquidityMutation, findPoolId } from '@/hooks/useAddLiquidityMutation';
 import { useSandshrewProvider } from '@/hooks/useSandshrewProvider';
 import { useFrbtcPremium } from '@/hooks/useFrbtcPremium';
-import { useFeeRate } from '@/hooks/useFeeRate';
 import { FRBTC_WRAP_FEE_PER_1000 } from '@/constants/alkanes';
 import { getConfig } from '@/utils/getConfig';
 import { getFutureBlockHeight } from '@/utils/amm';
@@ -41,6 +40,7 @@ export interface AtomicWrapAddLiquidityParams {
   maxSlippage: string;
   /** Deadline blocks from "now". */
   deadlineBlocks: number;
+  feeRate: number; // sats/vB — pass caller's useFeeRate instance (each hook instance has independent state)
   /** Optional pool id; mutation falls back to factory.FindPoolId if absent. */
   poolId?: { block: number; tx: number };
   /**
@@ -58,7 +58,6 @@ export function useAtomicWrapAddLiquidityMutation() {
   const provider = useSandshrewProvider();
   const addLiquidityMutation = useAddLiquidityMutation();
   const { data: premiumData } = useFrbtcPremium();
-  const fee = useFeeRate();
 
   const executeAtomicAddLiquidity = useCallback(
     async (params: AtomicWrapAddLiquidityParams) => {
@@ -140,7 +139,7 @@ export function useAtomicWrapAddLiquidityMutation() {
         token0Decimals: 8,
         token1Decimals: 8,
         maxSlippage: params.maxSlippage,
-        feeRate: fee.feeRate,
+        feeRate: params.feeRate,
         deadlineBlocks: params.deadlineBlocks,
         poolId: resolvedPoolId ?? undefined,
         overrideProtostones: protostones,
@@ -149,7 +148,7 @@ export function useAtomicWrapAddLiquidityMutation() {
         splitTransactions: params.splitTransactions ?? (network === 'mainnet'),
       } as any);
     },
-    [network, address, premiumData, fee.feeRate, addLiquidityMutation, provider],
+    [network, address, premiumData, addLiquidityMutation, provider],
   );
 
   return {

--- a/hooks/useAtomicWrapSwapMutation.ts
+++ b/hooks/useAtomicWrapSwapMutation.ts
@@ -27,7 +27,6 @@ import { useWallet } from '@/context/WalletContext';
 import { useSwapMutation } from '@/hooks/useSwapMutation';
 import { useSandshrewProvider } from '@/hooks/useSandshrewProvider';
 import { useFrbtcPremium } from '@/hooks/useFrbtcPremium';
-import { useFeeRate } from '@/hooks/useFeeRate';
 import { FRBTC_WRAP_FEE_PER_1000 } from '@/constants/alkanes';
 import { getConfig } from '@/utils/getConfig';
 import { getFutureBlockHeight } from '@/utils/amm';
@@ -47,6 +46,7 @@ export interface AtomicWrapSwapParams {
   maxSlippage: string;
   /** Deadline blocks from "now". */
   deadlineBlocks: number;
+  feeRate: number; // sats/vB — pass caller's useFeeRate instance (each hook instance has independent state)
   /**
    * Opt-in CPFP-chained 2-tx flow:
    *   Tx A: wrap-only — mints frBTC to a UTXO at the user's taproot.
@@ -68,7 +68,6 @@ export function useAtomicWrapSwapMutation() {
   const swapMutation = useSwapMutation();
   const provider = useSandshrewProvider();
   const { data: premiumData } = useFrbtcPremium();
-  const fee = useFeeRate();
 
   const executeAtomicSwap = useCallback(
     async (params: AtomicWrapSwapParams) => {
@@ -106,7 +105,7 @@ export function useAtomicWrapSwapMutation() {
         sellAmount: btcSats.toString(),
         buyAmount: params.quoteBuyAmount,
         maxSlippage: params.maxSlippage,
-        feeRate: fee.feeRate,
+        feeRate: params.feeRate,
         poolId: params.poolId,
         deadlineBlocks: params.deadlineBlocks,
         // Override protostones and addresses for atomic wrap+swap.
@@ -123,7 +122,7 @@ export function useAtomicWrapSwapMutation() {
         splitTransactions: params.splitTransactions ?? (network === 'mainnet'),
       } as any);
     },
-    [network, address, premiumData, fee.feeRate, swapMutation],
+    [network, address, premiumData, swapMutation, provider],
   );
 
   return {

--- a/hooks/useTokenToBtcSwap.ts
+++ b/hooks/useTokenToBtcSwap.ts
@@ -22,7 +22,6 @@ import { useCallback } from 'react';
 import { useWallet } from '@/context/WalletContext';
 import { useSwapMutation } from '@/hooks/useSwapMutation';
 import { useUnwrapMutation } from '@/hooks/useUnwrapMutation';
-import { useFeeRate } from '@/hooks/useFeeRate';
 import { useGlobalStore } from '@/stores/global';
 import { getConfig, getRpcUrl } from '@/utils/getConfig';
 import { getEsploraTx } from '@/lib/alkanes/rpc';
@@ -48,6 +47,7 @@ export interface TokenToBtcSwapParams {
   buyAmount: string;
   /** Pool id from the swap quote. */
   poolId?: { block: string | number; tx: string | number };
+  feeRate: number; // sats/vB — pass caller's useFeeRate instance (each hook instance has independent state)
   /** UI callback fired on every state transition. */
   onProgress: (progress: TokenToBtcSwapProgress) => void;
   /** UI callback fired when a tx is broadcast (for toast notifications). */
@@ -57,7 +57,6 @@ export interface TokenToBtcSwapParams {
 export function useTokenToBtcSwap() {
   const { network, address } = useWallet();
   const { maxSlippage, deadlineBlocks } = useGlobalStore();
-  const fee = useFeeRate();
   const swapMutation = useSwapMutation();
   const unwrapMutation = useUnwrapMutation();
   const config = getConfig(network);
@@ -78,7 +77,7 @@ export function useTokenToBtcSwap() {
         sellAmount: params.sellAmount,
         buyAmount: params.buyAmount,
         maxSlippage,
-        feeRate: fee.feeRate,
+        feeRate: params.feeRate,
         poolId: params.poolId,
         deadlineBlocks,
       });
@@ -188,7 +187,7 @@ export function useTokenToBtcSwap() {
 
       const unwrapRes = await unwrapMutation.mutateAsync({
         amount: frbtcAmount,
-        feeRate: fee.feeRate,
+        feeRate: params.feeRate,
       });
 
       if (!unwrapRes?.success || !unwrapRes.transactionId) {
@@ -214,7 +213,7 @@ export function useTokenToBtcSwap() {
 
       return { swapTxId, unwrapTxId: unwrapRes.transactionId };
     },
-    [network, address, maxSlippage, deadlineBlocks, fee.feeRate, swapMutation, unwrapMutation, config.FRBTC_ALKANE_ID],
+    [network, address, maxSlippage, deadlineBlocks, swapMutation, unwrapMutation, config.FRBTC_ALKANE_ID],
   );
 
   return {


### PR DESCRIPTION
## Summary
- Three atomic mutation hooks (`useAtomicWrapSwapMutation`, `useAtomicWrapAddLiquidityMutation`, `useTokenToBtcSwap`) each called `useFeeRate()` internally — each call returns its own independent state, so the user's fee-modal adjustment (bound to SwapShell's instance) was silently dropped on every atomic flow.
- Hooks now take `feeRate: number` as a param. SwapShell passes its `fee.feeRate` at the 3 call sites. Matches the canonical pattern already used by every other mutation hook (`useSwapMutation`, `useWrapMutation`, `useUnwrapMutation`, `useAddLiquidityMutation`, `useRemoveLiquidityMutation`, `useBtcSendMutation`, `useAlkaneSendMutation`).
- Incidental fix: `useAtomicWrapSwapMutation` deps array picks up `provider` (was a latent missing-dep — `provider` is captured in the callback body via `getFutureBlockHeight`).

## Test plan
- [ ] BTC → token swap (atomic wrap+swap): change fee in the modal, confirm the broadcast tx uses the chosen sat/vB
- [ ] Token → BTC swap (sequential swap+unwrap): change fee in the modal, confirm both legs broadcast at the chosen rate
- [ ] BTC + token → LP (atomic wrap+addLiquidity): change fee in the modal, confirm the tx uses the chosen rate
- [ ] No regression for non-atomic flows (plain swap, plain wrap, plain unwrap, add/remove LP, sends) — they were already correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)