### PR TITLE
feat(landing): home page chart data + pool value consistency

### DIFF
--- a/app/api/amm-volume/route.ts
+++ b/app/api/amm-volume/route.ts
@@ -1,18 +1,19 @@
 /**
  * Total AMM Volume API — proxies espo's `ammdata.get_total_volume_amm`.
  *
- * GET /api/amm-volume?limit=<n>
+ * GET /api/amm-volume
  *
- * Returns cumulative AMM volume time-series in USD (post-scaling). The
- * upstream espo module emits values as scaled bigints (`scale` field, default
- * 1e16) so we divide here and return plain JS numbers — consumers don't need
- * to know about the fixed-point encoding.
+ * Returns a daily-bucketed cumulative AMM volume series in USD. The upstream
+ * RPC paginates at 1000 points/page sorted ascending, so a single page only
+ * covers ~28 days. We fetch all pages in parallel here, bucket by date, and
+ * forward-fill missing days (cumulative volume is monotonic — a day with no
+ * recorded events inherits the prior day's value). The browser receives a
+ * tiny ~270-point series instead of ~7K raw event points.
  *
  * Upstream: https://api.alkanode.com/rpc method `ammdata.get_total_volume_amm`.
  * Override via env:
  *   ESPO_RPC_PRIMARY_URL    — primary JSON-RPC base. Default api.alkanode.com.
- *   ESPO_RPC_FALLBACK_URL   — fallback if primary fails. No default; set to
- *                             enable an alternate alkanode/subfrost host.
+ *   ESPO_RPC_FALLBACK_URL   — fallback if primary page-1 fails. No default.
  */
 
 import { NextResponse } from 'next/server';
@@ -21,54 +22,163 @@ const ESPO_RPC_PRIMARY = process.env.ESPO_RPC_PRIMARY_URL || 'https://api.alkano
 const ESPO_RPC_FALLBACK = process.env.ESPO_RPC_FALLBACK_URL || '';
 
 const UPSTREAM_TIMEOUT_MS = 8_000;
+const PAGE_SIZE = 1000;
+// Generous ceiling — currently ~8 pages of data exist (May 2026). Bump if the
+// chart starts visibly clipping at the historical end.
+const MAX_PAGES = 16;
+const ASSUMED_SECONDS_PER_BLOCK = 600;
 
 const FRESH_CACHE_HEADER = 'public, s-maxage=30, stale-while-revalidate=300';
 
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const limit = Math.min(Number(searchParams.get('limit') || 1000), 5000);
+interface UpstreamPoint {
+  height: number;
+  value: string;
+}
+interface UpstreamPage {
+  ok: boolean;
+  scale?: string;
+  unit?: string;
+  latest?: { height: number; value: string } | null;
+  points?: UpstreamPoint[];
+}
 
-  const callRpc = async (url: string) => {
-    const resp = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        method: 'ammdata.get_total_volume_amm',
-        params: { limit, page: 1 },
-        id: 1,
-      }),
-      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
-      cache: 'no-store',
-    });
-    if (!resp.ok) throw new Error(`http ${resp.status} (${url})`);
-    const j = await resp.json();
-    if (j?.error) throw new Error(`rpc error: ${JSON.stringify(j.error)}`);
-    if (!j?.result?.ok) throw new Error('rpc result not ok');
-    return j.result;
+async function fetchPage(url: string, page: number): Promise<UpstreamPage> {
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'ammdata.get_total_volume_amm',
+      params: { limit: PAGE_SIZE, page },
+      id: page,
+    }),
+    signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    cache: 'no-store',
+  });
+  if (!resp.ok) throw new Error(`http ${resp.status} (${url}, page ${page})`);
+  const j = await resp.json();
+  if (j?.error) throw new Error(`rpc error: ${JSON.stringify(j.error)}`);
+  if (!j?.result?.ok) throw new Error('rpc result not ok');
+  return j.result as UpstreamPage;
+}
+
+async function fetchAllPages(url: string) {
+  // Fire all pages in parallel. Individual page failures past page 1 are
+  // tolerated (we just skip them) — only a page-1 failure is fatal here.
+  const settled = await Promise.all(
+    Array.from({ length: MAX_PAGES }, (_, i) =>
+      fetchPage(url, i + 1).then(
+        (p) => ({ ok: true as const, page: i + 1, p }),
+        (err) => ({ ok: false as const, page: i + 1, err }),
+      ),
+    ),
+  );
+
+  const page1 = settled[0]!;
+  if (!page1.ok) throw page1.err;
+
+  const head = page1.p;
+  const allPoints: UpstreamPoint[] = [];
+  for (const r of settled) {
+    if (r.ok && Array.isArray(r.p.points)) allPoints.push(...r.p.points);
+  }
+
+  return {
+    points: allPoints,
+    scale: head.scale ?? '10000000000000000',
+    unit: head.unit ?? 'usd',
+    latest: head.latest ?? null,
+  };
+}
+
+function bucketByDay(
+  rawPoints: UpstreamPoint[],
+  latest: { height: number; value: string } | null,
+  scaleFloat: number,
+): { time: string; valueUsd: number }[] {
+  const points = rawPoints
+    .map((p) => ({ height: Number(p.height), valueUsd: Number(p.value) / scaleFloat }))
+    .filter((p) => Number.isFinite(p.height) && Number.isFinite(p.valueUsd));
+
+  const latestPt = latest
+    ? { height: Number(latest.height), valueUsd: Number(latest.value) / scaleFloat }
+    : null;
+
+  if (!points.length && !latestPt) return [];
+
+  // Estimate dates by anchoring `latest` to "now" and walking back at 600s/block.
+  // Drift over months is well below the 1-day bucket granularity.
+  const anchorHeight = latestPt?.height ?? points[points.length - 1]!.height;
+  const anchorMs = Date.now();
+  const heightToDate = (h: number): string => {
+    const ms = anchorMs - (anchorHeight - h) * ASSUMED_SECONDS_PER_BLOCK * 1000;
+    return new Date(ms).toISOString().slice(0, 10);
   };
 
+  // Bucket per ISO date — keep the highest cumulative value seen on that date.
+  const byDate = new Map<string, number>();
+  for (const p of points) {
+    const t = heightToDate(p.height);
+    const cur = byDate.get(t);
+    if (cur === undefined || p.valueUsd > cur) byDate.set(t, p.valueUsd);
+  }
+  if (latestPt) {
+    const today = heightToDate(latestPt.height);
+    if (!byDate.has(today) || byDate.get(today)! < latestPt.valueUsd) {
+      byDate.set(today, latestPt.valueUsd);
+    }
+  }
+
+  const entries = Array.from(byDate.entries())
+    .map(([time, valueUsd]) => ({ time, valueUsd }))
+    .sort((a, b) => (a.time < b.time ? -1 : a.time > b.time ? 1 : 0));
+
+  if (entries.length < 2) return entries;
+
+  // Forward-fill missing days. Cumulative volume only increases, so a day with
+  // no events inherits the prior day's value — without this the chart jumps
+  // across empty intervals (e.g. Aug → today) instead of drawing a continuous
+  // timeline.
+  const ONE_DAY_MS = 86_400_000;
+  const parseDay = (iso: string) =>
+    Date.UTC(
+      Number(iso.slice(0, 4)),
+      Number(iso.slice(5, 7)) - 1,
+      Number(iso.slice(8, 10)),
+    );
+
+  const startMs = parseDay(entries[0]!.time);
+  const endMs = parseDay(entries[entries.length - 1]!.time);
+
+  const filled: { time: string; valueUsd: number }[] = [];
+  let nextIdx = 0;
+  let lastValue = entries[0]!.valueUsd;
+  for (let cursor = startMs; cursor <= endMs; cursor += ONE_DAY_MS) {
+    const t = new Date(cursor).toISOString().slice(0, 10);
+    if (nextIdx < entries.length && entries[nextIdx]!.time === t) {
+      lastValue = entries[nextIdx]!.valueUsd;
+      nextIdx++;
+    }
+    filled.push({ time: t, valueUsd: lastValue });
+  }
+  return filled;
+}
+
+export async function GET() {
   try {
-    let result: any;
+    let result: Awaited<ReturnType<typeof fetchAllPages>>;
     try {
-      result = await callRpc(ESPO_RPC_PRIMARY);
+      result = await fetchAllPages(ESPO_RPC_PRIMARY);
     } catch (primaryErr) {
       if (!ESPO_RPC_FALLBACK) throw primaryErr;
-      console.warn(`[amm-volume] primary failed (${primaryErr instanceof Error ? primaryErr.message : 'unknown'}); falling back to ${ESPO_RPC_FALLBACK}`);
-      result = await callRpc(ESPO_RPC_FALLBACK);
+      console.warn(
+        `[amm-volume] primary failed (${primaryErr instanceof Error ? primaryErr.message : 'unknown'}); falling back to ${ESPO_RPC_FALLBACK}`,
+      );
+      result = await fetchAllPages(ESPO_RPC_FALLBACK);
     }
 
-    // Pre-divide by scale so consumers get plain JS numbers in USD.
-    const scaleBigInt = BigInt(result.scale || '10000000000000000');
-    const scaleFloat = Number(scaleBigInt);
-
-    const points = (result.points || [])
-      .map((p: any) => ({
-        height: Number(p.height),
-        valueUsd: Number(p.value) / scaleFloat,
-      }))
-      .filter((p: any) => Number.isFinite(p.height) && Number.isFinite(p.valueUsd));
-
+    const scaleFloat = Number(BigInt(result.scale));
+    const points = bucketByDay(result.points, result.latest, scaleFloat);
     const latest = result.latest
       ? {
           height: Number(result.latest.height),
@@ -77,19 +187,12 @@ export async function GET(request: Request) {
       : null;
 
     return NextResponse.json(
-      {
-        ok: true,
-        unit: result.unit || 'usd',
-        latest,
-        points,
-      },
+      { ok: true, unit: result.unit, latest, points },
       { headers: { 'Cache-Control': FRESH_CACHE_HEADER } },
     );
-  } catch (e: any) {
-    console.error('[amm-volume] failed:', e?.message || e);
-    return NextResponse.json(
-      { ok: false, error: e?.message || 'fetch failed' },
-      { status: 502 },
-    );
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'fetch failed';
+    console.error('[amm-volume] failed:', msg);
+    return NextResponse.json({ ok: false, error: msg }, { status: 502 });
   }
 }

--- a/app/components/CumulativeAmmVolume.tsx
+++ b/app/components/CumulativeAmmVolume.tsx
@@ -2,9 +2,7 @@
 
 import { useEffect, useMemo, useRef } from 'react';
 import { useTheme } from '@/context/ThemeContext';
-import { useAmmTotalVolume, type AmmVolumePoint } from '@/hooks/useAmmTotalVolume';
-
-const ASSUMED_SECONDS_PER_BLOCK = 600;
+import { useAmmTotalVolume } from '@/hooks/useAmmTotalVolume';
 
 function formatUsd(value: number): string {
   if (!Number.isFinite(value)) return '—';
@@ -13,62 +11,15 @@ function formatUsd(value: number): string {
   return `$${value.toFixed(0)}`;
 }
 
-/**
- * Convert sparse (height, valueUsd) points into a sorted, dedup'd
- * (time, value) series suitable for lightweight-charts.
- *
- * Espo only emits per-block-event points (no timestamps), so we estimate
- * each point's time by anchoring the latest point to "now" and walking
- * backward at 600s/block. Drift over a 30-day window is small enough for
- * a marketing-quality landing-page chart; precision isn't the goal.
- */
-function pointsToSeries(
-  points: AmmVolumePoint[],
-  latest: { height: number; valueUsd: number } | null,
-): { time: string; value: number }[] {
-  if (!points.length) return [];
-
-  const anchorHeight = latest?.height ?? points[points.length - 1]!.height;
-  const anchorMs = Date.now();
-
-  const heightToDate = (h: number): string => {
-    const blocksAgo = anchorHeight - h;
-    const ms = anchorMs - blocksAgo * ASSUMED_SECONDS_PER_BLOCK * 1000;
-    return new Date(ms).toISOString().slice(0, 10);
-  };
-
-  // Bucket per ISO date, keeping the *highest* cumulative value seen on that
-  // date — cumulative volume is monotonic so the last point in a bucket wins.
-  const byDate = new Map<string, number>();
-  for (const p of points) {
-    const t = heightToDate(p.height);
-    const cur = byDate.get(t);
-    if (cur === undefined || p.valueUsd > cur) byDate.set(t, p.valueUsd);
-  }
-
-  // If `latest` exists and isn't already in the series, append today's value
-  // — important when the indexed series ends mid-day on a low-volume block.
-  if (latest) {
-    const today = heightToDate(latest.height);
-    if (!byDate.has(today) || byDate.get(today)! < latest.valueUsd) {
-      byDate.set(today, latest.valueUsd);
-    }
-  }
-
-  return Array.from(byDate.entries())
-    .map(([time, value]) => ({ time, value }))
-    .sort((a, b) => (a.time < b.time ? -1 : a.time > b.time ? 1 : 0));
-}
-
 export default function CumulativeAmmVolume() {
   const { theme } = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<any>(null);
 
-  const { data, isLoading, isError } = useAmmTotalVolume(1000);
+  const { data, isLoading, isError } = useAmmTotalVolume();
 
   const series = useMemo(
-    () => (data ? pointsToSeries(data.points, data.latest) : []),
+    () => data?.points?.map((p) => ({ time: p.time, value: p.valueUsd })) ?? [],
     [data],
   );
 

--- a/app/components/HomeMarketsButton.tsx
+++ b/app/components/HomeMarketsButton.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useMemo, useState, lazy, Suspense } from 'react';
+import { useState, lazy, Suspense } from 'react';
 import { useRouter } from 'next/navigation';
 import { ChevronRight } from 'lucide-react';
-import { usePools } from '@/hooks/usePools';
-import { useAllPoolStats } from '@/hooks/usePoolData';
+import { usePoolMarkets } from '@/hooks/usePoolMarkets';
 import { saveSwapPair } from '@/app/swap/swapPair';
 import type { PoolSummary } from '@/app/swap/types';
 
@@ -19,32 +18,7 @@ export default function HomeMarketsButton() {
   const [hasOpenedOnce, setHasOpenedOnce] = useState(false);
   const [volumePeriod, setVolumePeriod] = useState<'24h' | '30d'>('30d');
 
-  const { data: poolsData } = usePools({ sortBy: 'tvl', order: 'desc' });
-  const { data: poolStats } = useAllPoolStats();
-
-  const markets = useMemo<PoolSummary[]>(() => {
-    const basePools = poolsData?.items ?? [];
-
-    const statsMap = new Map<string, NonNullable<typeof poolStats>[string]>();
-    if (poolStats) {
-      for (const [, stats] of Object.entries(poolStats)) {
-        statsMap.set(stats.poolId, stats);
-      }
-    }
-
-    return basePools.map(pool => {
-      const stats = statsMap.get(pool.id);
-      return {
-        ...pool,
-        tvlUsd: pool.tvlUsd || stats?.tvlUsd || 0,
-        token0TvlUsd: pool.token0TvlUsd || stats?.tvlToken0 || (pool.tvlUsd || 0) / 2,
-        token1TvlUsd: pool.token1TvlUsd || stats?.tvlToken1 || (pool.tvlUsd || 0) / 2,
-        vol24hUsd: pool.vol24hUsd || stats?.volume24hUsd || 0,
-        vol30dUsd: pool.vol30dUsd || stats?.volume30dUsd || 0,
-        apr: pool.apr || stats?.apr || 0,
-      } as PoolSummary;
-    });
-  }, [poolsData?.items, poolStats]);
+  const { markets } = usePoolMarkets();
 
   const handleSelect = (pool: PoolSummary) => {
     saveSwapPair(pool.token0, pool.token1);

--- a/app/components/SplashScreen.tsx
+++ b/app/components/SplashScreen.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { useAlkanesSDK } from '@/context/AlkanesSDKContext';
 
 /**
- * Full-screen splash with animated canvas snowflake + progress bar.
+ * Full-screen splash with the SUBFROST wordmark + progress bar.
  * Renders as a React component so it doesn't cause hydration mismatches.
  *
  * Tracks REAL loading milestones to drive progress:
@@ -53,7 +53,6 @@ export default function SplashScreen() {
   const [imagesLoaded, setImagesLoaded] = useState(false);
   const [pageLoaded, setPageLoaded] = useState(false);
 
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const readyRef = useRef(false);
   const startRef = useRef(0);
   const frameRef = useRef<number>(0);
@@ -149,104 +148,15 @@ export default function SplashScreen() {
   }, [isInitialized, fontsLoaded, imagesLoaded, pageLoaded]);
 
   // ---------------------------------------------------------------------------
-  // Canvas animation
+  // Progress bar animation
   // ---------------------------------------------------------------------------
 
   useEffect(() => {
     if (!visible || fading) return;
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
 
-    const dpr = window.devicePixelRatio || 1;
-    const W = 160, H = 160;
-    canvas.width = W * dpr;
-    canvas.height = H * dpr;
-    ctx.scale(dpr, dpr);
-
-    const t0 = startRef.current;
     let progress = 0, targetP = 0;
-
-    // Particles
-    const pts: { x: number; y: number; vx: number; vy: number; s: number; a: number }[] = [];
-    for (let i = 0; i < 15; i++) {
-      pts.push({
-        x: Math.random() * W, y: Math.random() * H,
-        vx: (Math.random() - 0.5) * 0.2, vy: (Math.random() - 0.5) * 0.2,
-        s: Math.random() * 1.2 + 0.4, a: Math.random() * 0.3 + 0.08,
-      });
-    }
-
     const bar = document.getElementById('sf-splash-bar');
     const pct = document.getElementById('sf-splash-pct');
-
-    function draw(t: number) {
-      ctx!.clearRect(0, 0, W, H);
-      const cx = W / 2, cy = H / 2;
-      const pulse = 1 + Math.sin(t * 1.5) * 0.03;
-      const sz = 55 * pulse;
-      const rot = t * 0.08;
-
-      // Particles
-      for (const p of pts) {
-        p.x += p.vx; p.y += p.vy;
-        if (p.x < 0) p.x = W; if (p.x > W) p.x = 0;
-        if (p.y < 0) p.y = H; if (p.y > H) p.y = 0;
-        ctx!.beginPath(); ctx!.arc(p.x, p.y, p.s, 0, 6.283);
-        ctx!.fillStyle = `rgba(91,156,255,${p.a})`; ctx!.fill();
-      }
-
-      ctx!.save(); ctx!.translate(cx, cy); ctx!.rotate(rot);
-
-      // Two-pass glow
-      for (let pass = 0; pass < 2; pass++) {
-        if (pass === 0) {
-          ctx!.globalAlpha = 0.25; ctx!.lineWidth = 3.5; ctx!.shadowBlur = 25;
-        } else {
-          ctx!.globalAlpha = 1; ctx!.lineWidth = 1.5; ctx!.shadowBlur = 8;
-        }
-        ctx!.shadowColor = '#5b9cff'; ctx!.strokeStyle = '#5b9cff'; ctx!.lineCap = 'round';
-
-        for (let i = 0; i < 6; i++) {
-          ctx!.save(); ctx!.rotate(i * 1.0472);
-          ctx!.beginPath(); ctx!.moveTo(0, 0); ctx!.lineTo(sz, 0); ctx!.stroke();
-          const bp = [0.35, 0.6, 0.82], bl = [0.38, 0.28, 0.16], ba = 0.6981;
-          for (let j = 0; j < 3; j++) {
-            const px = bp[j] * sz, ln = bl[j] * sz;
-            ctx!.beginPath(); ctx!.moveTo(px, 0);
-            ctx!.lineTo(px + ln * Math.cos(ba), -ln * Math.sin(ba)); ctx!.stroke();
-            ctx!.beginPath(); ctx!.moveTo(px, 0);
-            ctx!.lineTo(px + ln * Math.cos(-ba), -ln * Math.sin(-ba)); ctx!.stroke();
-          }
-          if (pass === 1) {
-            const d = 4;
-            ctx!.fillStyle = 'rgba(199,224,254,0.35)';
-            ctx!.beginPath();
-            ctx!.moveTo(sz - d, 0); ctx!.lineTo(sz, -d);
-            ctx!.lineTo(sz + d, 0); ctx!.lineTo(sz, d);
-            ctx!.closePath(); ctx!.fill(); ctx!.stroke();
-          }
-          ctx!.restore();
-        }
-      }
-
-      // Inner hex
-      ctx!.globalAlpha = 0.35; ctx!.lineWidth = 1; ctx!.shadowBlur = 4;
-      const hs = sz * 0.18;
-      ctx!.beginPath();
-      for (let i = 0; i < 6; i++) {
-        const hx = hs * Math.cos(i * 1.0472), hy = hs * Math.sin(i * 1.0472);
-        if (i === 0) ctx!.moveTo(hx, hy); else ctx!.lineTo(hx, hy);
-      }
-      ctx!.closePath(); ctx!.stroke();
-
-      // Center dot
-      ctx!.globalAlpha = 1; ctx!.shadowBlur = 12; ctx!.shadowColor = '#c7e0fe';
-      ctx!.beginPath(); ctx!.arc(0, 0, 2.5, 0, 6.283);
-      ctx!.fillStyle = '#c7e0fe'; ctx!.fill();
-      ctx!.restore();
-    }
 
     function tick() {
       const milestoneTarget = milestonePRef.current;
@@ -268,8 +178,6 @@ export default function SplashScreen() {
 
       progress += (targetP - progress) * 0.08;
 
-      const elapsed = (performance.now() - t0) / 1000;
-      draw(elapsed);
       if (bar) bar.style.width = Math.min(progress, 100) + '%';
       if (pct) pct.textContent = Math.round(Math.min(progress, 100)) + '%';
 
@@ -303,12 +211,18 @@ export default function SplashScreen() {
         pointerEvents: fading ? 'none' : undefined,
       }}
     >
-      <canvas
-        ref={canvasRef}
-        width={160}
-        height={160}
-        style={{ width: 80, height: 80 }}
-      />
+      <div
+        style={{
+          fontFamily: 'var(--font-satoshi), ui-sans-serif, system-ui, sans-serif',
+          fontWeight: 700,
+          fontSize: 36,
+          letterSpacing: '0.05em',
+          color: '#ffffff',
+          lineHeight: 1,
+        }}
+      >
+        SUBFROST
+      </div>
       <div
         style={{
           marginTop: 28,

--- a/app/components/TrendingPairs.tsx
+++ b/app/components/TrendingPairs.tsx
@@ -2,8 +2,7 @@
 
 import { useMemo } from 'react';
 import Link from 'next/link';
-import { usePools } from '@/hooks/usePools';
-import { useAllPoolStats } from '@/hooks/usePoolData';
+import { usePoolMarkets } from '@/hooks/usePoolMarkets';
 import TokenIcon from '@/app/components/TokenIcon';
 import HomeMarketsButton from '@/app/components/HomeMarketsButton';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -44,51 +43,21 @@ function formatUsd(n?: number, showZeroAsDash = false) {
 
 export default function TrendingPairs() {
   const { t } = useTranslation();
-  const { data } = usePools({ sortBy: 'tvl', order: 'desc', limit: 200 });
-
-  // Enhanced pool stats from our local API (TVL, Volume, APR)
-  const { data: poolStats } = useAllPoolStats();
+  const { markets } = usePoolMarkets();
 
   const pairs = useMemo(() => {
-    const filtered = data?.items ?? [];
+    const hasAny24hVolume = markets.some((p) => (p.vol24hUsd ?? 0) > 0);
+    const hasAny30dVolume = markets.some((p) => (p.vol30dUsd ?? 0) > 0);
 
-    // Create stats lookup map (fallback)
-    const statsMap = new Map<string, NonNullable<typeof poolStats>[string]>();
-    if (poolStats) {
-      for (const [, stats] of Object.entries(poolStats)) {
-        statsMap.set(stats.poolId, stats);
-      }
-    }
-
-    // Merge stats with pools (usePools already provides TVL/volume from OYL Alkanode)
-    const enrichedPools = filtered.map(p => {
-      const stats = statsMap.get(p.id);
-      return {
-        ...p,
-        tvlUsd: p.tvlUsd || stats?.tvlUsd || 0,
-        vol24hUsd: p.vol24hUsd || stats?.volume24hUsd || 0,
-        vol30dUsd: p.vol30dUsd || stats?.volume30dUsd || 0,
-      };
-    });
-
-    // Check if any pool has volume data
-    const hasAny24hVolume = enrichedPools.some(p => (p.vol24hUsd ?? 0) > 0);
-    const hasAny30dVolume = enrichedPools.some(p => (p.vol30dUsd ?? 0) > 0);
-
-    // Sort by 24h volume if any exists, otherwise 30d volume, otherwise TVL
-    return enrichedPools
+    // Sort by 24h volume if any exists, otherwise 30d volume, otherwise TVL.
+    return [...markets]
       .sort((a, b) => {
-        if (hasAny24hVolume) {
-          return (b.vol24hUsd ?? 0) - (a.vol24hUsd ?? 0);
-        }
-        if (hasAny30dVolume) {
-          return (b.vol30dUsd ?? 0) - (a.vol30dUsd ?? 0);
-        }
-        // Final fallback to TVL
+        if (hasAny24hVolume) return (b.vol24hUsd ?? 0) - (a.vol24hUsd ?? 0);
+        if (hasAny30dVolume) return (b.vol30dUsd ?? 0) - (a.vol30dUsd ?? 0);
         return (b.tvlUsd ?? 0) - (a.tvlUsd ?? 0);
       })
       .slice(0, 1);
-  }, [data?.items, poolStats]);
+  }, [markets]);
 
   return (
     <div className="sf-card h-full">

--- a/app/swap/SwapShell.tsx
+++ b/app/swap/SwapShell.tsx
@@ -18,8 +18,7 @@ import { usePendingTxs } from "@/hooks/usePendingTxs";
 import { useGlobalStore } from "@/stores/global";
 import { useFeeRate } from "@/hooks/useFeeRate";
 import { useBtcPrice } from "@/hooks/useBtcPrice";
-import { usePools } from "@/hooks/usePools";
-import { useAllPoolStats } from "@/hooks/usePoolData";
+import { usePoolMarkets } from "@/hooks/usePoolMarkets";
 import { useModalStore } from "@/stores/modals";
 import BigNumber from 'bignumber.js';
 import { useWrapMutation } from "@/hooks/useWrapMutation";
@@ -92,38 +91,16 @@ function getBridgeRoute(from: string, to: string): string {
 export default function SwapShell() {
   const { t } = useTranslation();
 
-  // Markets from API: all pools sorted by TVL desc
-  const { data: poolsData, isLoading: isLoadingPools } = usePools({ sortBy: 'tvl', order: 'desc' });
-
-  // Enhanced pool stats from our local API (TVL, Volume, APR)
-  const { data: poolStats, isLoading: isLoadingPoolStats } = useAllPoolStats();
-
-  // Merge pool data with stats from /api/pools/stats (fallback for any missing data)
-  const markets = useMemo<PoolSummary[]>(() => {
-    const basePools = poolsData?.items ?? [];
-
-    // If poolStats available, use as fallback overlay
-    const statsMap = new Map<string, NonNullable<typeof poolStats>[string]>();
-    if (poolStats) {
-      for (const [, stats] of Object.entries(poolStats)) {
-        statsMap.set(stats.poolId, stats);
-      }
-    }
-
-    return basePools.map(pool => {
-      const stats = statsMap.get(pool.id);
-
-      return {
-        ...pool,
-        tvlUsd: pool.tvlUsd || stats?.tvlUsd || 0,
-        token0TvlUsd: pool.token0TvlUsd || stats?.tvlToken0 || (pool.tvlUsd || 0) / 2,
-        token1TvlUsd: pool.token1TvlUsd || stats?.tvlToken1 || (pool.tvlUsd || 0) / 2,
-        vol24hUsd: pool.vol24hUsd || stats?.volume24hUsd || 0,
-        vol30dUsd: pool.vol30dUsd || stats?.volume30dUsd || 0,
-        apr: pool.apr || stats?.apr || 0,
-      } as PoolSummary;
-    });
-  }, [poolsData?.items, poolStats]);
+  // Markets, loading flags, and merge-derived booleans all come from the
+  // shared `usePoolMarkets` hook so this surface stays consistent with
+  // TrendingPairs / HomeMarketsButton / MarketsGrid by construction.
+  const {
+    markets,
+    isLoadingPools,
+    isLoadingPoolStats,
+    poolStatsHasData,
+    hasVolumeDataMerged,
+  } = usePoolMarkets();
 
   const marketType = 'spot' as const;
 
@@ -414,16 +391,6 @@ export default function SwapShell() {
 
     return sorted[0];
   }, [markets]);
-
-  // Check if we have meaningful volume data merged into markets
-  const hasVolumeDataMerged = useMemo(() => {
-    return markets.some(p => (p.vol24hUsd ?? 0) > 0 || (p.vol30dUsd ?? 0) > 0);
-  }, [markets]);
-
-  // Check if poolStats actually has data (not just loaded as empty object)
-  const poolStatsHasData = useMemo(() => {
-    return poolStats !== undefined && Object.keys(poolStats).length > 0;
-  }, [poolStats]);
 
   // Initialize swap tokens to the trending pair (highest volume) on every visit.
   // A saved pair is only honored as a one-shot handoff from explicit cross-page

--- a/hooks/__tests__/usePools.test.ts
+++ b/hooks/__tests__/usePools.test.ts
@@ -55,7 +55,7 @@ vi.mock('@/utils/getConfig', () => ({
 vi.mock('@/queries/keys', () => ({
   queryKeys: {
     pools: {
-      list: (network: string, paramsKey: string) => ['pools', network, paramsKey],
+      list: (network: string) => ['pools', network],
     },
   },
 }));

--- a/hooks/useAmmTotalVolume.ts
+++ b/hooks/useAmmTotalVolume.ts
@@ -1,16 +1,17 @@
 /**
  * useAmmTotalVolume — cumulative AMM volume time-series for the landing page.
  *
- * Hits `/api/amm-volume`, which proxies espo's `ammdata.get_total_volume_amm`
- * (alkanode by default, configurable via env). Values come pre-scaled to USD
- * floats — no fixed-point math required at the call site.
+ * Hits `/api/amm-volume`, which paginates espo's `ammdata.get_total_volume_amm`
+ * server-side and returns a small daily-bucketed series (already forward-filled
+ * across days with no events). Values are pre-scaled to USD floats — no
+ * fixed-point math required at the call site.
  */
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
 
 export interface AmmVolumePoint {
-  height: number;
+  time: string;     // ISO date 'YYYY-MM-DD'
   valueUsd: number;
 }
 
@@ -21,8 +22,8 @@ export interface AmmTotalVolumeData {
   points: AmmVolumePoint[];
 }
 
-async function fetchAmmTotalVolume(limit: number): Promise<AmmTotalVolumeData> {
-  const resp = await fetch(`/api/amm-volume?limit=${limit}`, { cache: 'no-store' });
+async function fetchAmmTotalVolume(): Promise<AmmTotalVolumeData> {
+  const resp = await fetch('/api/amm-volume', { cache: 'no-store' });
   if (!resp.ok) {
     const j = await resp.json().catch(() => ({}));
     throw new Error(`amm-volume HTTP ${resp.status}: ${j?.error ?? 'unknown'}`);
@@ -32,10 +33,10 @@ async function fetchAmmTotalVolume(limit: number): Promise<AmmTotalVolumeData> {
   return j;
 }
 
-export function useAmmTotalVolume(limit = 1000) {
+export function useAmmTotalVolume() {
   return useQuery({
-    queryKey: ['ammTotalVolume', limit],
-    queryFn: () => fetchAmmTotalVolume(limit),
+    queryKey: ['ammTotalVolume'],
+    queryFn: fetchAmmTotalVolume,
     staleTime: 60_000, // 1 min — landing-page chart, not real-time critical
     refetchOnWindowFocus: false,
   });

--- a/hooks/usePoolMarkets.ts
+++ b/hooks/usePoolMarkets.ts
@@ -1,0 +1,71 @@
+/**
+ * usePoolMarkets — single source of truth for the merged `PoolSummary[]`
+ * surface used by every market display in the app.
+ *
+ * Combines `usePools` (raw pool list from REST + curated) with
+ * `useAllPoolStats` (aggregator-derived TVL/volume/APR overlay) and applies
+ * the canonical `pool.X || stats?.Y || 0` merge in one place.
+ *
+ * Replaces three byte-identical merge blocks that previously lived in
+ * TrendingPairs, HomeMarketsButton, and SwapShell — keeping them in lockstep
+ * was the only thing standing between this app and a "DIESEL/frBTC shows
+ * $1.469M on the home card but $0 on the markets grid" bug. Centralizing
+ * here means any future tweak to the merge formula is guaranteed to apply
+ * everywhere at once.
+ */
+import { useMemo } from 'react';
+
+import { usePools, type UsePoolsParams } from '@/hooks/usePools';
+import { useAllPoolStats } from '@/hooks/usePoolData';
+import type { PoolSummary } from '@/app/swap/types';
+
+export interface PoolMarketsResult {
+  markets: PoolSummary[];
+  isLoadingPools: boolean;
+  isLoadingPoolStats: boolean;
+  /** True when /api/pools/stats actually returned non-empty data. */
+  poolStatsHasData: boolean;
+  /** True when at least one market in the merged set has > 0 24h or 30d volume. */
+  hasVolumeDataMerged: boolean;
+}
+
+export function usePoolMarkets(params?: UsePoolsParams): PoolMarketsResult {
+  const { data: poolsData, isLoading: isLoadingPools } = usePools(params);
+  const { data: poolStats, isLoading: isLoadingPoolStats } = useAllPoolStats();
+
+  const markets = useMemo<PoolSummary[]>(() => {
+    const basePools = poolsData?.items ?? [];
+
+    const statsMap = new Map<string, NonNullable<typeof poolStats>[string]>();
+    if (poolStats) {
+      for (const [, stats] of Object.entries(poolStats)) {
+        statsMap.set(stats.poolId, stats);
+      }
+    }
+
+    return basePools.map((pool) => {
+      const stats = statsMap.get(pool.id);
+      return {
+        ...pool,
+        tvlUsd: pool.tvlUsd || stats?.tvlUsd || 0,
+        token0TvlUsd: pool.token0TvlUsd || stats?.tvlToken0 || (pool.tvlUsd || 0) / 2,
+        token1TvlUsd: pool.token1TvlUsd || stats?.tvlToken1 || (pool.tvlUsd || 0) / 2,
+        vol24hUsd: pool.vol24hUsd || stats?.volume24hUsd || 0,
+        vol30dUsd: pool.vol30dUsd || stats?.volume30dUsd || 0,
+        apr: pool.apr || stats?.apr || 0,
+      } as PoolSummary;
+    });
+  }, [poolsData?.items, poolStats]);
+
+  const poolStatsHasData = useMemo(
+    () => poolStats !== undefined && Object.keys(poolStats).length > 0,
+    [poolStats],
+  );
+
+  const hasVolumeDataMerged = useMemo(
+    () => markets.some((p) => (p.vol24hUsd ?? 0) > 0 || (p.vol30dUsd ?? 0) > 0),
+    [markets],
+  );
+
+  return { markets, isLoadingPools, isLoadingPoolStats, poolStatsHasData, hasVolumeDataMerged };
+}

--- a/hooks/usePools.ts
+++ b/hooks/usePools.ts
@@ -4,6 +4,7 @@
  * Primary: provider.dataApiGetAllPoolsDetails (single HTTP call, returns TVL/volume/APR)
  * Fallback: provider.alkanesGetAllPoolsWithDetails (N+1 RPC sims, no TVL/volume)
  */
+import { useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useWallet } from '@/context/WalletContext';
@@ -698,13 +699,24 @@ export function usePools(params: UsePoolsParams = {}) {
   const { ALKANE_FACTORY_ID } = getConfig(network);
   const { provider } = useAlkanesSDK();
 
-  const paramsKey = `${params.search ?? ''}|${params.limit ?? 100}|${params.offset ?? 0}|${params.sortBy ?? 'tvl'}|${params.order ?? 'desc'}`;
+  // Cache key is keyed on `network` only. search/sort/limit/offset are applied
+  // as a post-query selector below, so every consumer in the app — TrendingPairs,
+  // HomeMarketsButton, SwapShell, etc. — shares a single React Query cache entry
+  // and a single upstream fetch per network. Without this, two callers with
+  // different `limit` values raced each other through the fallback chain and
+  // could land on different rungs (REST vs SDK WASM), surfacing different
+  // numbers for the same pool on the same page.
+  const select = useCallback(
+    (rawItems: PoolsListItem[]) => applyFiltersAndPagination(rawItems, params),
+    [params.search, params.sortBy, params.order, params.limit, params.offset],
+  );
 
-  return useQuery<{ items: PoolsListItem[]; total: number }>({
-    queryKey: queryKeys.pools.list(network, paramsKey),
+  return useQuery<PoolsListItem[], Error, { items: PoolsListItem[]; total: number }>({
+    queryKey: queryKeys.pools.list(network),
     retry: 3,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
     enabled: !!network && !!ALKANE_FACTORY_ID && !!provider,
+    select,
     queryFn: async () => {
       if (!provider) {
         throw new Error('SDK provider not available');
@@ -727,7 +739,7 @@ export function usePools(params: UsePoolsParams = {}) {
         } catch (e) {
           console.warn('[usePools] regtest-local: Direct simulate failed:', e);
         }
-        return { items, total: items.length };
+        return items;
       }
 
       // Mainnet (and signet/testnet) primary: prefetch curated pool IDs
@@ -749,20 +761,34 @@ export function usePools(params: UsePoolsParams = {}) {
         }
       }
 
-      // Merge fallback pool entries onto the curated set instead of replacing
-      // it. The original code overwrote `items = await fallback(...)` whenever
-      // a fallback returned anything non-empty, which silently nuked the
-      // curated DIESEL/MIST/Bee/DUST entries when /api/pools/cached returned
-      // a 2-pool partial list (the espo proxy serves stale partial data
-      // before it's fully populated). Symptom: BTC→Token swap picker only
-      // surfaced frBTC/bUSD/FIRE despite the curated path having succeeded.
+      // Merge fallback pool entries onto the curated set. New ids get pushed;
+      // existing ids get *enriched* — REST fills in TVL/volume/APR/lpTotalSupply
+      // fields that curated leaves undefined (curated only seeds id, tokens,
+      // and reserves from on-chain opcode 999). Reserves and labels are
+      // never overwritten because curated reads state-trie directly per Rule
+      // SoT-2; aggregator data lags. Without this enrichment the four
+      // curated mainnet pools (DIESEL/frBTC, MIST, Bee, DUST) ended up with
+      // `vol30dUsd === undefined` from `usePools` and could only show real
+      // numbers when `useAllPoolStats` happened to succeed — which it doesn't
+      // when `/api/pools/stats` 502s. Verified 2026-05-09 against the live
+      // payload: REST returns `poolVolume30dInUsd: 1517216…` for `2:77087`.
       const mergeItems = (extra: PoolsListItem[]) => {
-        const seen = new Set(items.map((p) => p.id));
+        const byId = new Map(items.map((p) => [p.id, p]));
         for (const p of extra) {
-          if (!seen.has(p.id)) {
+          const existing = byId.get(p.id);
+          if (!existing) {
             items.push(p);
-            seen.add(p.id);
+            byId.set(p.id, p);
+            continue;
           }
+          existing.tvlUsd        ??= p.tvlUsd;
+          existing.token0TvlUsd  ??= p.token0TvlUsd;
+          existing.token1TvlUsd  ??= p.token1TvlUsd;
+          existing.vol24hUsd     ??= p.vol24hUsd;
+          existing.vol7dUsd      ??= p.vol7dUsd;
+          existing.vol30dUsd     ??= p.vol30dUsd;
+          existing.apr           ??= p.apr;
+          existing.lpTotalSupply ??= p.lpTotalSupply;
         }
       };
 
@@ -903,7 +929,9 @@ export function usePools(params: UsePoolsParams = {}) {
         items = items.filter(p => p.tvlUsd === undefined || p.tvlUsd >= MIN_TVL_USD);
       }
 
-      return applyFiltersAndPagination(items, params);
+      // Return raw items — search/sort/limit/offset are applied per consumer
+      // via the `select` selector above so a single fetch serves every caller.
+      return items;
     },
   });
 }

--- a/queries/keys.ts
+++ b/queries/keys.ts
@@ -66,8 +66,8 @@ export const queryKeys = {
   // Pools
   // -------------------------------------------------------------------------
   pools: {
-    list: (network: string, paramsKey: string) =>
-      ['pools', network, paramsKey] as const,
+    list: (network: string) =>
+      ['pools', network] as const,
     dynamic: (network: string, factoryId: string) =>
       ['dynamic-pools', network, factoryId] as const,
     tokenPairs: (network: string, alkaneId: string, paramsKey: string) =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,6 +42,7 @@
     "e2e-tests",
     "__tests__/devnet",
     "vendor",
-    "services"
+    "services",
+    "reference"
   ]
 }


### PR DESCRIPTION
## Summary
- Reworks `app/api/amm-volume/route.ts` and `useAmmTotalVolume` to drive real Total AMM Volume + chart data on the landing surfaces.
- Consolidates pool value handling across `SwapShell`, `TrendingPairs`, `HomeMarketsButton`, `CumulativeAmmVolume`, and `SplashScreen` so pool values read consistently app-wide.
- Adds `hooks/usePoolMarkets.ts` and tightens `usePools` / query keys; minor `tsconfig.json` adjustment.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run hooks/__tests__/usePools.test.ts`
- [ ] Load landing page — verify Total AMM Volume number + chart render with real data
- [ ] Open swap shell, trending pairs, and home markets — pool values match across surfaces
- [ ] Verify splash screen still renders correctly after simplifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)