### PR TITLE
hotfix(rpc): revert mainnet to /v4/subfrost — /v6/subfrost lacks REST sub-paths

### DIFF
--- a/app/api/rpc/[[...segments]]/route.ts
+++ b/app/api/rpc/[[...segments]]/route.ts
@@ -23,19 +23,15 @@ import { NextRequest, NextResponse } from 'next/server';
 
 // All RPC endpoints point to subfrost infrastructure.
 //
-// JOURNAL ENTRY (2026-05-10): mainnet flipped from /v4/<token> to /v6/subfrost.
-// /v6/subfrost is the CDN-fronted mainnet endpoint. Benchmarked ~30× faster
-// than /v4/<token> under 27-way parallel `protorunesbyoutpoint` load
-// (0.29s wall time vs 8.7s on /v4/<token>) — the user-visible
-// "perpetual loading" window during wallet UTXO cache prewarm.
-// Other networks left on /v4/<token> — only mainnet has /v6/subfrost.
-//
-// Aggressive bursts (>~18 concurrent requests) trigger HTTP 429 rate limits,
-// which the proxy forwards to the client unchanged. The wallet cache's
-// `fetchWithRetry` (queries/account.ts) handles 429s with [0, 500, 1500]ms
-// per-call backoff, so partial-throttle scenarios still complete cleanly.
+// JOURNAL ENTRY (2026-05-10): mainnet uses /v4/subfrost (canonical).
+// Tried /v6/subfrost briefly (faster on metashrew_view but doesn't support
+// the REST sub-paths /get-all-amm-tx-history / /get-pool-swap-history that
+// the activity feed and swap history depend on; rolled back same day).
+// /v4/subfrost benchmarks ~9× faster than /v4/<token> on protorunesbyoutpoint
+// fanout (0.92s wall time for 27-way parallel vs 8.7s on /v4/<token>).
+// Other networks left on /v4/<token> — only mainnet has /v4/subfrost.
 const RPC_ENDPOINTS: Record<string, string> = {
-  mainnet: 'https://mainnet.subfrost.io/v6/subfrost',
+  mainnet: 'https://mainnet.subfrost.io/v4/subfrost',
   testnet: 'https://testnet.subfrost.io/v4/5d37098b75581792a44b9d230d48aa75',
   signet: 'https://signet.subfrost.io/v4/5d37098b75581792a44b9d230d48aa75',
   regtest: 'https://regtest.subfrost.io/v4/5d37098b75581792a44b9d230d48aa75',
@@ -46,9 +42,9 @@ const RPC_ENDPOINTS: Record<string, string> = {
 };
 
 // Batch JSON-RPC requests are more reliably handled by the explicit /jsonrpc path.
-// Mainnet uses /v6/subfrost (CDN-fronted, handles both single + batch).
+// Mainnet uses /v4/subfrost (the canonical mainnet endpoint shared by the rest of the app).
 const BATCH_RPC_ENDPOINTS: Record<string, string> = {
-  mainnet: 'https://mainnet.subfrost.io/v6/subfrost',
+  mainnet: 'https://mainnet.subfrost.io/v4/subfrost',
   testnet: 'https://testnet.subfrost.io/v4/jsonrpc',
   signet: 'https://signet.subfrost.io/v4/jsonrpc',
   regtest: 'https://regtest.subfrost.io/v4/jsonrpc',


### PR DESCRIPTION
## TL;DR

PR #106 flipped mainnet to \`/v6/subfrost\` expecting a faster CDN-fronted endpoint. \`/v6/subfrost\` **is** faster on JSON-RPC \`metashrew_view\` calls (~30× under parallel load) but **does not support the REST sub-paths** that the data API depends on. Production has been silently 404ing on the activity feed, swap history, alkane balance discovery, and pool aggregator since #106 merged at 18:11 UTC. **Symptoms include "swap circle chokes then app crashes."**

## The data

| Endpoint | \`/v6/subfrost\` | \`/v4/subfrost\` |
|---|---|---|
| \`/get-all-amm-tx-history\` | **404** | 200 |
| \`/get-pool-swap-history\` | **404** | 200 |
| \`/get-alkanes-by-address\` | **404** | 200 |
| \`/get-all-pools-details\` | **404** | 200 |

## What this PR does

Reverts the three \`mainnet\` constants in \`app/api/rpc/[[...segments]]/route.ts\` from \`/v6/subfrost\` back to \`/v4/subfrost\`:

- \`RPC_ENDPOINTS.mainnet\`
- \`BATCH_RPC_ENDPOINTS.mainnet\`
- \`FALLBACK_ENDPOINTS.mainnet\` was already \`/v4/jsonrpc\` — left unchanged

\`/v4/subfrost\` is the canonical path used by every other route in the app (\`token-details\`, \`btc-candles\`, \`fees\`, \`alkane-balances\`, \`token-names\`, \`AlkanesSDKContext\`, \`queries/market\`). It supports both JSON-RPC and REST sub-paths.

## What we keep from #106's perf work

\`/v4/subfrost\` is still **~9× faster than \`/v4/<token>\`** on the \`protorunesbyoutpoint\` fanout (0.92s wall time for 27-way parallel vs 8.7s on \`/v4/<token>\`). The cache-prewarm UX win is preserved.

## A correct future migration to /v6/subfrost would need either:

(a) \`/v6\` gains REST sub-path support upstream, or
(b) the proxy dual-routes — JSON-RPC to \`/v6/subfrost\`, REST sub-paths to \`/v4/subfrost\`.

## Test plan

- [ ] Localhost: \`curl localhost:3000/api/rpc/mainnet/get-all-amm-tx-history\` returns 200
- [ ] Localhost: mainnet swap completes without "Method not found" / 404 errors in network tab
- [ ] Production: activity feed renders after deploy
- [ ] Production: swap history renders after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)