### PR TITLE
fix(pools): trigger alkanode fallback also on 200-with-zero-pools

### DIFF
--- a/app/api/pools/cached/route.ts
+++ b/app/api/pools/cached/route.ts
@@ -60,6 +60,26 @@ export async function GET(request: Request) {
     let data: any;
     try {
       data = await fetchPools(baseUrl);
+
+      // Subfrost upstream sometimes returns 200 OK with `total: 0` even when
+      // pools exist (indexer drift, partial outage). On mainnet specifically,
+      // the alkanode mirror is authoritative — if primary returns suspiciously
+      // empty AND a fallback is configured, fall through to it.
+      const total = Number(data?.data?.total ?? 0);
+      if (fallbackBase && total === 0) {
+        console.warn(`[pools/cached] primary returned 0 pools (likely indexer drift); checking fallback ${fallbackBase}`);
+        try {
+          const fallbackData = await fetchPools(fallbackBase);
+          const fallbackTotal = Number(fallbackData?.data?.total ?? 0);
+          if (fallbackTotal > total) {
+            console.warn(`[pools/cached] fallback returned ${fallbackTotal} pools; using fallback data`);
+            data = fallbackData;
+          }
+        } catch (fallbackErr) {
+          // Fallback failed — keep primary's empty response rather than 502.
+          console.warn(`[pools/cached] fallback also failed: ${fallbackErr instanceof Error ? fallbackErr.message : 'unknown'}`);
+        }
+      }
     } catch (primaryErr) {
       if (!fallbackBase) throw primaryErr;
       console.warn(`[pools/cached] primary failed (${primaryErr instanceof Error ? primaryErr.message : 'unknown'}); falling back to ${fallbackBase}`);


### PR DESCRIPTION
## Symptom

Mainnet swap UI shows "No pools available." Pool list is empty across the entire app.

## Root cause

Subfrost mainnet's \`/get-all-pools-details\` is returning HTTP 200 with empty data:

\`\`\`json
{"data":{"total":0,"pools":[],"largestPool":null,...},"statusCode":200}
\`\`\`

Meanwhile the alkanode mirror at \`oyl.alkanode.com\` has **143 pools** indexed and returning correctly.

The existing fallback in \`app/api/pools/cached/route.ts\` only fires on a thrown error (HTTP 5xx, network failure, abort). A 200-with-empty-data was treated as success and the empty response shadowed real pool data.

This is upstream indexer drift, **not** a routing bug introduced by recent perf work — it happens regardless of whether we hit \`/v4/<token>\`, \`/v4/subfrost\`, or \`/v6/subfrost\`.

## Fix

Extend the fallback trigger condition to also fire when:
- Primary returned successfully
- A fallback URL is configured for this network
- Primary's \`data.total === 0\`

If the fallback returns more pools than primary (any \`> 0\` beats \`0\`), use it. If the fallback also fails or returns 0, keep primary's empty response (don't 502 on a genuinely empty network).

20 LOC, contained to \`app/api/pools/cached/route.ts\`.

## Verified locally

Before:
\`\`\`
{"data":{"count":0,"pools":[],"total":0,...}}
\`\`\`

After:
\`\`\`
[pools/cached] primary returned 0 pools (likely indexer drift); checking fallback https://oyl.alkanode.com
[pools/cached] fallback returned 143 pools; using fallback data
{"data":{"count":143,...,"pools":[{"poolName":"DIESEL / FRBTC",...},...]}}
\`\`\`

## Test plan

- [ ] Localhost mainnet: pools render in swap picker
- [ ] Localhost mainnet swap completes (DIESEL → BTC etc.)
- [ ] Production: pool list renders after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)