### PR TITLE
fix(balances): alkanode REST fallback when subfrost alkane indexer drifts

### DIFF
--- a/app/api/rpc/[[...segments]]/route.ts
+++ b/app/api/rpc/[[...segments]]/route.ts
@@ -494,6 +494,49 @@ export async function POST(
       }
     }
 
+    // alkanes_* retry on transient gateway errors. The /v4/subfrost gateway
+    // returns transient JSON-RPC errors (~3-7% of bursts) on
+    // alkanes_protorunesbyoutpoint and friends — "metashrew-unwrap" /
+    // "error decoding response body" / similar non-deterministic signatures.
+    // Each failed call cascades through the wallet cache's fetchWithRetry
+    // (3× per outpoint) and, if even one outpoint exhausts retries, blanks
+    // the whole alkane balance display. This block adds a server-side retry
+    // (up to 2 extra attempts, ~100ms backoff) so transient errors don't
+    // reach the client. If retries are also exhausted we forward the last
+    // response as-is (the client cache will retry, and Layer 2's alkanode
+    // fallback in queries/account.ts catches the steady-state empty case).
+    {
+      const isAlkanesRpc = !Array.isArray(body) &&
+        typeof body?.method === 'string' &&
+        body.method.startsWith('alkanes_');
+      const upstreamFailed = !response.ok || !!data?.error;
+      if (isAlkanesRpc && upstreamFailed && network) {
+        for (let attempt = 0; attempt < 2; attempt++) {
+          await new Promise((r) => setTimeout(r, 100 * (attempt + 1)));
+          try {
+            const retryResp = await fetch(targetUrl, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(body),
+            });
+            const retryText = await retryResp.text();
+            try {
+              const retryData = JSON.parse(retryText);
+              if (retryResp.ok && !retryData?.error) {
+                if (attempt > 0 || !response.ok) {
+                  console.warn(`[RPC Proxy] alkanes_* retry succeeded on attempt ${attempt + 2} for ${body.method}`);
+                }
+                return NextResponse.json(retryData);
+              }
+              // Update `data` so a downstream fallback (or the client-cache
+              // retry loop) sees the most-recent response, not a stale one.
+              data = retryData;
+            } catch { /* retry non-JSON; loop again */ }
+          } catch { /* retry threw; loop again */ }
+        }
+      }
+    }
+
     // Non-200 status with valid JSON body — forward the JSON-RPC error as-is
     if (!response.ok) {
       console.error(`[RPC Proxy] Upstream HTTP ${response.status} for ${method}`);

--- a/queries/account.ts
+++ b/queries/account.ts
@@ -306,10 +306,71 @@ export async function fetchAlkaneBalancesViaProtobuf(
     }
   }
 
+  // Step 4: alkanode REST fallback when subfrost's alkane indexer drift
+  // causes every dust outpoint to come back with an empty balance sheet.
+  //
+  // The 2026-05-10 mainnet incident: subfrost upstream returned valid HTTP 200
+  // for every alkanes_protorunesbyoutpoint call but with `balances: []` in the
+  // payload, while alkanode reported the wallet's actual DIESEL holdings via
+  // /get-alkanes-by-address. The per-outpoint fanout above can't tell the
+  // difference between "this outpoint is genuinely empty" and "subfrost is
+  // lying" — both shapes are structurally identical. So at the aggregate
+  // level we check: dust UTXOs exist (so SOMETHING should have value) but
+  // we got zero alkanes. That's the only signature of indexer drift.
+  //
+  // SoT-1 still holds: subfrost is primary. Alkanode is consulted only when
+  // subfrost has zero data. If even one outpoint produces a balance, we
+  // trust subfrost completely and skip the fallback.
+  if (aggregate.size === 0 && dustUtxos.length > 0 && network === 'mainnet') {
+    const fallback = await tryAlkanodeAlkaneBalances(address);
+    if (fallback && fallback.length > 0) {
+      console.warn(`[alkaneBalances] subfrost returned 0 alkanes for ${dustUtxos.length} dust UTXOs at ${address}; using alkanode fallback (${fallback.length} entries)`);
+      return fallback;
+    }
+  }
+
   return Array.from(aggregate, ([id, bal]) => {
     const [block, tx] = id.split(':');
     return { alkaneId: { block, tx }, balance: bal.toString() };
   });
+}
+
+// Alkanode REST fallback for `fetchAlkaneBalancesViaProtobuf`. Used only
+// when subfrost upstream's alkane indexer returns 200-with-empty across every
+// dust outpoint at an address. Returns the same shape as the primary path so
+// callers can swap freely.
+//
+// Set `ESPO_MAINNET_FALLBACK_URL=""` (env) to disable. Defaults to alkanode.
+async function tryAlkanodeAlkaneBalances(
+  address: string,
+): Promise<{ alkaneId: { block: string; tx: string }; balance: string }[] | null> {
+  const fallbackBase = (typeof process !== 'undefined' && process.env?.ESPO_MAINNET_FALLBACK_URL !== undefined)
+    ? process.env.ESPO_MAINNET_FALLBACK_URL
+    : 'https://oyl.alkanode.com';
+  if (!fallbackBase) return null;
+  try {
+    const resp = await fetch(`${fallbackBase.replace(/\/$/, '')}/get-alkanes-by-address`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    const items: any[] = Array.isArray(data?.data) ? data.data : [];
+    return items
+      .map((item) => {
+        const block = String(item?.alkaneId?.block ?? '');
+        const tx = String(item?.alkaneId?.tx ?? '');
+        const balance = String(item?.balance ?? '0');
+        if (!block || !tx) return null;
+        return { alkaneId: { block, tx }, balance };
+      })
+      .filter((x): x is { alkaneId: { block: string; tx: string }; balance: string } => x !== null);
+  } catch (err) {
+    console.warn('[alkaneBalances] alkanode fallback threw:', err);
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

Mainnet wallets show empty alkane balances (DIESEL = 0) in the swap UI even though the wallet actually holds DIESEL. Pools render correctly. Only the per-wallet alkane balance is broken.

Verified live: address \`bc1pf8c420ues7wvh0fgmh56675xsm4as33ms006tee876h3v08y5yqqfruu2w\` reports DIESEL=264482 via alkanode but \`balances: []\` from subfrost across all 15 dust UTXOs.

## Why pools work but balances don't

| | Pools | Balances |
|---|---|---|
| Endpoint shape | REST \`/get-all-pools-details\` | JSON-RPC \`alkanes_protorunesbyoutpoint\` |
| Fanout granularity | Single call per network | Per dust UTXO (5-30 calls in parallel) |
| Existing alkanode fallback | ✅ PR #109 + #111 | ❌ none |

PRs #109 and #111 wired alkanode as a REST fallback for the proxy's REST sub-path branch. Balance fetching uses JSON-RPC and a per-outpoint fanout, so the proxy can't transparently fall back to alkanode's per-address \`/get-alkanes-by-address\` — different wire shapes, different fan-out granularities.

## The fix (two layers)

### Layer 2 — \`queries/account.ts:fetchAlkaneBalancesViaProtobuf\` (primary fix)

After the per-outpoint \`Promise.all\` aggregation, if:
- aggregate is empty (no alkane balances summed)
- dust UTXOs > 0 (so SOMETHING should have had value)
- network is mainnet

…fetch alkanode's \`/get-alkanes-by-address\` as a fallback. If the response contains alkane entries, return them instead of the empty primary result.

**SoT-1 still holds**: subfrost is primary. Alkanode is consulted ONLY when subfrost has zero data. If even one outpoint produces a balance, we trust subfrost completely.

### Layer 1 — \`app/api/rpc/[[...segments]]/route.ts\` (defensive retry)

The \`/v4/subfrost\` gateway returns transient JSON-RPC errors (\"metashrew-unwrap\", \"error decoding response body\") for ~3-7% of \`alkanes_*\` bursts. Each failure cascades through the wallet cache's \`fetchWithRetry\` (3× per outpoint); if even one outpoint exhausts retries, \`Promise.all\` rejects and React Query blanks the whole balance display.

This block adds a server-side retry (up to 2 extra attempts, ~100ms backoff) for \`alkanes_*\` methods on a non-2xx OR JSON-RPC error response. Mirrors the metashrew_view pattern from PR #110.

## What this does NOT change

- \`alkaneBalanceQueryOptions\` retry config (\`retry: 3\` stays)
- Metashrew /v6 dual-routing from PR #108/#110
- No SoT-1 violation: alkanode is last-resort, only when subfrost has zero data

## Test plan

- [ ] Localhost mainnet: connect wallet with DIESEL, balance displays correctly within ~3s
- [ ] Verify alkanode is queried only when subfrost returns empty (server log: \`[alkaneBalances] subfrost returned 0 alkanes ... using alkanode fallback\`)
- [ ] Verify a wallet with no alkanes still shows 0 (alkanode also returns 0, primary stays in control)
- [ ] Production: balance display restores after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)