### PR TITLE
fix(espo): harden third-party host config + route balance fallback th…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,18 @@ Available helpers (canonical surface):
 
 When you next edit any of those files, swap the raw fetch for the corresponding `rpc.*` helper.
 
+### ⚠️ Mainnet metashrew routing — DO NOT MOVE `metashrew_height` ONTO /v6
+
+`app/api/rpc/[[...segments]]/route.ts` splits mainnet metashrew traffic by method:
+
+| Method | Endpoint | Why |
+|--------|----------|-----|
+| `metashrew_view` | `/v6/subfrost` (sticky, fast) | 12–30× faster on the wallet UTXO prewarm fanout (parallel `alkanes_protorunesbyoutpoint`). |
+| `metashrew_height` | `/v4/subfrost` (gateway) | /v6 rate-limits aggressive bursts. The SDK's `WebProvider::sync` polls `metashrew_height` every ~500ms for up to 30s while waiting for the indexer to catch up to bitcoind, and reliably trips /v6's burst limit (429 after ~7-8 calls in ~3.5s). The 429 propagates as "Network error: HTTP error: 429" and the swap aborts. /v4 doesn't rate-limit and the single-call latency penalty is negligible. |
+| Everything else (`alkanes_*`, `bitcoin_*`, `esplora_*`, REST sub-paths) | `/v4/subfrost` | /v6 only serves metashrew JSON-RPC. |
+
+DO NOT consolidate `metashrew_height` back onto /v6 for "consistency" — the perf benefit is zero (single trivial call, no fanout) and the cost is total swap failure during normal 1-block indexer-lag windows (which happen every ~10 minutes on mainnet). Verified 2026-05-10 (commit `3d3b48eb`).
+
 ### Indexer Sync — Proactive Probe in `alkanesExecuteTyped`
 
 `lib/alkanes/execute.ts:alkanesExecuteTyped` calls `provider.waitForIndexer()` before dispatching to `alkanesExecuteWithStrings` / `alkanesExecuteFull`. This catches the transient `metashrew_height < bitcoind_blockcount` window on mainnet (sometimes a block apart for ~10–30s) up-front, instead of letting the SDK's internal 30s timeout fire and bury the swap on "Building Transaction".

--- a/app/api/token-names/__tests__/empty-fallback.test.ts
+++ b/app/api/token-names/__tests__/empty-fallback.test.ts
@@ -1,0 +1,173 @@
+/**
+ * 200-with-empty fallback in `/api/token-names`.
+ *
+ * Subfrost's `/get-alkanes` intermittently returns valid HTTP 200 with
+ * `data: { tokens: [] }` during indexer drift (same incident shape as
+ * PRs #108, #111, #112, #113 for sibling endpoints). The original route
+ * only fell back on network errors / non-2xx — empty 200s slipped through
+ * and the swap page showed `Loaded 0 token entries` while pair pickers
+ * rendered as numeric IDs.
+ *
+ * This suite mocks `fetch` at the upstream layer to exercise:
+ *   - primary 200 with empty tokens → fallback fires and is used
+ *   - primary 200 with non-empty tokens → fallback NOT fired
+ *   - primary 200 empty + fallback also empty → empty result returned (no crash)
+ *   - primary 200 empty + fallback throws → empty result, no crash
+ *   - non-mainnet networks → no fallback configured, primary used as-is
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { GET } from '../route';
+
+const SUBFROST_URL = 'https://mainnet.subfrost.io/v4/subfrost/get-alkanes';
+const ALKANODE_URL = 'https://oyl.alkanode.com/get-alkanes';
+
+function makeReq(network: string, limit?: number) {
+  const url = new URL('http://localhost/api/token-names');
+  url.searchParams.set('network', network);
+  if (limit) url.searchParams.set('limit', String(limit));
+  return new Request(url.toString());
+}
+
+function tokenResp(tokens: Array<{ block: number; tx: number; name?: string; symbol?: string; priceUsd?: number }>) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      data: {
+        tokens: tokens.map((t) => ({
+          id: { block: t.block, tx: t.tx },
+          name: t.name,
+          symbol: t.symbol,
+          priceUsd: t.priceUsd,
+        })),
+      },
+    }),
+  } as unknown as Response;
+}
+
+describe('token-names route — 200-with-empty fallback', () => {
+  const fetchSpy = vi.fn();
+  const origFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    // Force a unique limit per test so the route's in-process `fresh` cache
+    // never serves a hit from a sibling test's previous run.
+    vi.clearAllMocks();
+    fetchSpy.mockReset();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('falls back to alkanode when subfrost returns 200 with empty tokens', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url === SUBFROST_URL) return Promise.resolve(tokenResp([]));
+      if (url === ALKANODE_URL) {
+        return Promise.resolve(
+          tokenResp([
+            { block: 2, tx: 0, name: 'DIESEL', symbol: 'DIESEL' },
+            { block: 32, tx: 0, name: 'frBTC', symbol: 'frBTC' },
+          ]),
+        );
+      }
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    const res = await GET(makeReq('mainnet', 501));
+    const body = await res.json();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[0][0]).toBe(SUBFROST_URL);
+    expect(fetchSpy.mock.calls[1][0]).toBe(ALKANODE_URL);
+    expect(body.count).toBe(2);
+    expect(body.names['2:0']).toEqual({ name: 'DIESEL', symbol: 'DIESEL' });
+  });
+
+  it('does NOT fall back when subfrost returns at least one token', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      tokenResp([{ block: 2, tx: 0, name: 'DIESEL', symbol: 'DIESEL' }]),
+    );
+
+    const res = await GET(makeReq('mainnet', 502));
+    const body = await res.json();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe(SUBFROST_URL);
+    expect(body.count).toBe(1);
+    expect(body.names['2:0']).toEqual({ name: 'DIESEL', symbol: 'DIESEL' });
+  });
+
+  it('returns empty result (no crash) when both subfrost AND alkanode return empty', async () => {
+    fetchSpy.mockImplementation(() => Promise.resolve(tokenResp([])));
+
+    const res = await GET(makeReq('mainnet', 503));
+    const body = await res.json();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(body.count).toBe(0);
+    expect(body.names).toEqual({});
+  });
+
+  it('returns empty result (no crash) when fallback fetch throws', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url === SUBFROST_URL) return Promise.resolve(tokenResp([]));
+      if (url === ALKANODE_URL) return Promise.reject(new Error('connection refused'));
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    const res = await GET(makeReq('mainnet', 504));
+    const body = await res.json();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(body.count).toBe(0);
+  });
+
+  it('does not trigger fallback on non-mainnet networks (no fallback configured)', async () => {
+    fetchSpy.mockResolvedValueOnce(tokenResp([]));
+
+    const res = await GET(makeReq('regtest', 505));
+    const body = await res.json();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // Verify upstream was regtest's, NOT alkanode's
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      'https://regtest.subfrost.io/v4/subfrost/get-alkanes',
+    );
+    expect(body.count).toBe(0);
+  });
+
+  it('preserves price extraction from fallback response (regression: PR #112 fields)', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url === SUBFROST_URL) return Promise.resolve(tokenResp([]));
+      if (url === ALKANODE_URL) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: {
+              tokens: [
+                {
+                  id: { block: 2, tx: 0 },
+                  name: 'DIESEL',
+                  symbol: 'DIESEL',
+                  priceUsd: 0.0042,
+                  priceInSatoshi: 5,
+                },
+              ],
+            },
+          }),
+        } as unknown as Response);
+      }
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    const res = await GET(makeReq('mainnet', 506));
+    const body = await res.json();
+
+    expect(body.prices['2:0']).toEqual({ priceUsd: 0.0042, priceInSatoshi: 5 });
+  });
+});

--- a/app/api/token-names/route.ts
+++ b/app/api/token-names/route.ts
@@ -128,16 +128,41 @@ export async function GET(request: Request) {
 
   try {
     let response: Response;
+    let parsed: any;
     try {
       response = await fetchAlkanes(baseUrl);
+      parsed = await response.json();
     } catch (primaryErr) {
       if (!fallbackBase) throw primaryErr;
       console.warn(`[token-names] primary upstream failed (${primaryErr instanceof Error ? primaryErr.message : 'unknown'}); falling back to ${fallbackBase}`);
       response = await fetchAlkanes(fallbackBase);
+      parsed = await response.json();
     }
 
-    const data = await response.json();
-    const tokens: any[] = data?.data?.tokens || [];
+    let tokens: any[] = parsed?.data?.tokens || [];
+
+    // 200-with-empty fallback. Subfrost's /get-alkanes intermittently returns
+    // valid HTTP 200 with `data: { tokens: [] }` during indexer drift (same
+    // class as PRs #108/#111/#112/#113). The 4xx/5xx catch above doesn't fire
+    // on this shape — the upstream looks healthy, just empty. Retry against
+    // alkanode and use its response if it has tokens.
+    //
+    // Skipped when primary already IS the fallback base (no point checking
+    // alkanode twice) or when no fallback is configured.
+    if (fallbackBase && tokens.length === 0 && baseUrl !== fallbackBase) {
+      console.warn(`[token-names] primary returned 0 tokens (likely indexer drift); checking ${fallbackBase}`);
+      try {
+        const fallbackResp = await fetchAlkanes(fallbackBase);
+        const fallbackParsed = await fallbackResp.json();
+        const fallbackTokens: any[] = fallbackParsed?.data?.tokens || [];
+        if (fallbackTokens.length > tokens.length) {
+          console.warn(`[token-names] fallback returned ${fallbackTokens.length} tokens; using fallback data`);
+          tokens = fallbackTokens;
+        }
+      } catch (fallbackErr) {
+        console.warn(`[token-names] empty-fallback failed: ${fallbackErr instanceof Error ? fallbackErr.message : 'unknown'}`);
+      }
+    }
 
     // Build name map AND a parallel price map. Espo's /get-alkanes
     // returns priceUsd / busdPoolPriceInUsd / priceInSatoshi per token

--- a/app/swap/components/PoolDetailsCard.tsx
+++ b/app/swap/components/PoolDetailsCard.tsx
@@ -14,7 +14,11 @@ type Props = {
   bare?: boolean;
 };
 
-const ALKANODE_RPC_URL = 'https://api.alkanode.com/rpc';
+// Same env knob as `lib/alkanes/rpc.ts` — overrides the alkanode JSON-RPC host
+// for the pizzafun namespace lookup. Falls back to the default alkanode URL.
+const ALKANODE_RPC_URL =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_ESPO_RPC_URL) ||
+  'https://api.alkanode.com/rpc';
 
 /**
  * Resolve the pizza.fun series ID (symbol) for a given alkane ID.

--- a/lib/alkanes/rpc.ts
+++ b/lib/alkanes/rpc.ts
@@ -459,7 +459,14 @@ export interface AmmPoolsResponse {
   total: number;
 }
 
-const ALKANODE_RPC_URL = 'https://api.alkanode.com/rpc';
+// Override via `NEXT_PUBLIC_ESPO_RPC_URL` if alkanode is unreachable and an
+// alternate host with the same `ammdata.*` / `pizzafun.*` JSON-RPC contract is
+// available. Parallel to the server-side `ESPO_RPC_PRIMARY_URL` used by
+// `app/api/amm-volume/route.ts`; kept as a separate var because this one is
+// read in browser context and needs the `NEXT_PUBLIC_` prefix to be inlined.
+const ALKANODE_RPC_URL =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_ESPO_RPC_URL) ||
+  'https://api.alkanode.com/rpc';
 
 /**
  * Fetch all AMM pools from the alkanode data service.

--- a/queries/__tests__/alkane-balance-rest-fallback.test.ts
+++ b/queries/__tests__/alkane-balance-rest-fallback.test.ts
@@ -1,0 +1,202 @@
+/**
+ * REST fallback path in `queries/account.ts::fetchAlkaneBalancesViaProtobuf`.
+ *
+ * Originally added in PR #112 to recover the balance display when subfrost's
+ * per-outpoint indexer drifts and returns `balance_sheet.cached.balances: []`
+ * for every dust UTXO at an address. Originally fetched
+ * `https://oyl.alkanode.com/get-alkanes-by-address` directly from the browser
+ * — a CLAUDE.md "no raw fetch in app code" violation that also relied on
+ * permissive third-party CORS.
+ *
+ * Refactored to route through `/api/rpc/{network}/get-alkanes-by-address`
+ * (the existing proxy, which has the 200-with-empty fallback chain wired
+ * server-side and reads `ESPO_MAINNET_FALLBACK_URL` from the server env).
+ *
+ * This suite mocks the rpc helpers + global fetch and asserts the fallback
+ * fires when (and only when) the documented signature matches.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the rpc.ts helpers BEFORE importing account.ts so the imported
+// `fetchAlkaneBalancesViaProtobuf` picks up the mocks.
+vi.mock('@/lib/alkanes/rpc', () => ({
+  getAddressUtxos: vi.fn(),
+  getProtorunesByOutpoint: vi.fn(),
+  getAddressMempoolTxs: vi.fn(),
+  getAlkaneInfoBatch: vi.fn(),
+}));
+
+import { fetchAlkaneBalancesViaProtobuf } from '../account';
+import * as rpc from '@/lib/alkanes/rpc';
+
+const ADDRESS = 'bc1p0eyy0testaddressformockingpurposesonly0000000';
+
+// Helpers --------------------------------------------------------------
+
+function makeDustUtxos(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    txid: 'a'.repeat(64).slice(0, 63) + i.toString(16),
+    vout: 0,
+    value: 546,
+  }));
+}
+
+function emptyBalanceSheet() {
+  return { balance_sheet: { cached: { balances: [] } } };
+}
+
+function balanceSheet(block: number, tx: number, amount: string | number) {
+  return { balance_sheet: { cached: { balances: [{ block, tx, amount }] } } };
+}
+
+function mockFallbackResponse(items: Array<{ block: string; tx: string; balance: string }>) {
+  return {
+    ok: true,
+    json: async () => ({
+      data: items.map((i) => ({
+        alkaneId: { block: i.block, tx: i.tx },
+        balance: i.balance,
+      })),
+    }),
+  } as unknown as Response;
+}
+
+// Test suite -----------------------------------------------------------
+
+describe('fetchAlkaneBalancesViaProtobuf — REST fallback', () => {
+  const fetchSpy = vi.fn();
+  const origFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchSpy.mockReset();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('fires fallback when subfrost returns empty for every dust UTXO on mainnet', async () => {
+    const dust = makeDustUtxos(3);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+
+    fetchSpy.mockResolvedValue(
+      mockFallbackResponse([{ block: '2', tx: '0', balance: '264482' }]),
+    );
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe('/api/rpc/mainnet/get-alkanes-by-address');
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address: ADDRESS }),
+    });
+    expect(result).toEqual([
+      { alkaneId: { block: '2', tx: '0' }, balance: '264482' },
+    ]);
+  });
+
+  it('does NOT fire fallback when subfrost returns at least one balance', async () => {
+    const dust = makeDustUtxos(3);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint)
+      .mockResolvedValueOnce(balanceSheet(2, 0, 100))
+      .mockResolvedValueOnce(emptyBalanceSheet())
+      .mockResolvedValueOnce(emptyBalanceSheet());
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      { alkaneId: { block: '2', tx: '0' }, balance: '100' },
+    ]);
+  });
+
+  it('does NOT fire fallback on non-mainnet networks (alkanode hosts mainnet only)', async () => {
+    const dust = makeDustUtxos(3);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+
+    const result = await fetchAlkaneBalancesViaProtobuf('regtest', ADDRESS);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('does NOT fire fallback when address has no dust UTXOs', async () => {
+    // Wallet holds only BTC, no token-carrying dust outpoints. The
+    // empty-aggregate signature alone is not enough — we also require
+    // dustUtxos.length > 0, otherwise the user just doesn't hold alkanes.
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue([
+      { txid: 'a'.repeat(64), vout: 0, value: 100_000 }, // non-dust BTC
+    ]);
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    expect(rpc.getProtorunesByOutpoint).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty when fallback itself returns no data (subfrost + alkanode both empty)', async () => {
+    // Genuinely empty wallet that happens to have a few dust UTXOs (e.g. spent
+    // inscription dust). Fallback fires, returns empty, primary's empty
+    // aggregate is returned — no phantom data injected.
+    const dust = makeDustUtxos(2);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+
+    fetchSpy.mockResolvedValue(mockFallbackResponse([]));
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([]);
+  });
+
+  it('routes through proxy URL, not direct alkanode (regression: PR #2 violation)', async () => {
+    // Hard guarantee: no client-side raw fetch to oyl.alkanode.com.
+    // The proxy reads ESPO_MAINNET_FALLBACK_URL server-side and handles
+    // the subfrost→alkanode fallback chain; the browser must only hit
+    // the same-origin proxy.
+    const dust = makeDustUtxos(1);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+    fetchSpy.mockResolvedValue(mockFallbackResponse([]));
+
+    await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    for (const call of fetchSpy.mock.calls) {
+      const url = String(call[0]);
+      expect(url).not.toMatch(/alkanode\.com/);
+      expect(url).not.toMatch(/^https?:\/\//); // must be same-origin
+    }
+  });
+
+  it('survives fallback fetch throwing (network error) without crashing the caller', async () => {
+    const dust = makeDustUtxos(1);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+    fetchSpy.mockRejectedValue(new Error('connection refused'));
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    // Fallback exception is caught; the primary's empty aggregate is returned.
+    expect(result).toEqual([]);
+  });
+
+  it('survives fallback returning non-2xx without crashing the caller', async () => {
+    const dust = makeDustUtxos(1);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+    fetchSpy.mockResolvedValue({ ok: false, status: 502, json: async () => ({}) } as unknown as Response);
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+    expect(result).toEqual([]);
+  });
+});

--- a/queries/account.ts
+++ b/queries/account.ts
@@ -322,9 +322,9 @@ export async function fetchAlkaneBalancesViaProtobuf(
   // subfrost has zero data. If even one outpoint produces a balance, we
   // trust subfrost completely and skip the fallback.
   if (aggregate.size === 0 && dustUtxos.length > 0 && network === 'mainnet') {
-    const fallback = await tryAlkanodeAlkaneBalances(address);
+    const fallback = await tryRestAlkanesByAddress(network, address);
     if (fallback && fallback.length > 0) {
-      console.warn(`[alkaneBalances] subfrost returned 0 alkanes for ${dustUtxos.length} dust UTXOs at ${address}; using alkanode fallback (${fallback.length} entries)`);
+      console.warn(`[alkaneBalances] subfrost returned 0 alkanes for ${dustUtxos.length} dust UTXOs at ${address}; using REST fallback (${fallback.length} entries)`);
       return fallback;
     }
   }
@@ -335,21 +335,23 @@ export async function fetchAlkaneBalancesViaProtobuf(
   });
 }
 
-// Alkanode REST fallback for `fetchAlkaneBalancesViaProtobuf`. Used only
-// when subfrost upstream's alkane indexer returns 200-with-empty across every
-// dust outpoint at an address. Returns the same shape as the primary path so
-// callers can swap freely.
+// REST fallback for `fetchAlkaneBalancesViaProtobuf`. Used only when subfrost
+// upstream's alkane indexer returns 200-with-empty across every dust outpoint
+// at an address. Returns the same shape as the primary path so callers can
+// swap freely.
 //
-// Set `ESPO_MAINNET_FALLBACK_URL=""` (env) to disable. Defaults to alkanode.
-async function tryAlkanodeAlkaneBalances(
+// Routes through `/api/rpc/{network}/get-alkanes-by-address` so the proxy's
+// 200-with-empty fallback chain (see `app/api/rpc/[[...segments]]/route.ts`)
+// can transparently fall back to `ESPO_MAINNET_FALLBACK_URL` (default
+// `https://oyl.alkanode.com`) when subfrost returns empty. This keeps the
+// fallback-host config server-side (single source of truth) and avoids a raw
+// browser → third-party fetch that depended on permissive CORS at alkanode.
+async function tryRestAlkanesByAddress(
+  network: string,
   address: string,
 ): Promise<{ alkaneId: { block: string; tx: string }; balance: string }[] | null> {
-  const fallbackBase = (typeof process !== 'undefined' && process.env?.ESPO_MAINNET_FALLBACK_URL !== undefined)
-    ? process.env.ESPO_MAINNET_FALLBACK_URL
-    : 'https://oyl.alkanode.com';
-  if (!fallbackBase) return null;
   try {
-    const resp = await fetch(`${fallbackBase.replace(/\/$/, '')}/get-alkanes-by-address`, {
+    const resp = await fetch(`/api/rpc/${network}/get-alkanes-by-address`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ address }),
@@ -368,7 +370,7 @@ async function tryAlkanodeAlkaneBalances(
       })
       .filter((x): x is { alkaneId: { block: string; tx: string }; balance: string } => x !== null);
   } catch (err) {
-    console.warn('[alkaneBalances] alkanode fallback threw:', err);
+    console.warn('[alkaneBalances] REST fallback threw:', err);
     return null;
   }
 }
@@ -549,7 +551,7 @@ export function walletUtxoCacheQueryOptions(deps: WalletUtxoCacheDeps) {
       // consulted only when subfrost has zero data.
       if (alkaneMap.size === 0 && dustUtxos.length > 0 && deps.network === 'mainnet') {
         const fallbackByAddress = await Promise.all(
-          addresses.map((addr) => tryAlkanodeAlkaneBalances(addr).then((res) => ({ addr, res }))),
+          addresses.map((addr) => tryRestAlkanesByAddress(deps.network, addr).then((res) => ({ addr, res }))),
         );
         const totalFallbackEntries = fallbackByAddress.reduce(
           (sum, { res }) => sum + (res?.length ?? 0),
@@ -557,9 +559,9 @@ export function walletUtxoCacheQueryOptions(deps: WalletUtxoCacheDeps) {
         );
         if (totalFallbackEntries > 0) {
           console.warn(
-            `[walletUtxoCache] subfrost returned 0 alkanes for ${dustUtxos.length} dust UTXOs; using alkanode fallback (${totalFallbackEntries} entries across ${fallbackByAddress.length} addresses)`,
+            `[walletUtxoCache] subfrost returned 0 alkanes for ${dustUtxos.length} dust UTXOs; using REST fallback (${totalFallbackEntries} entries across ${fallbackByAddress.length} addresses)`,
           );
-          // Credit each address's alkanode balances to the first dust UTXO
+          // Credit each address's fallback balances to the first dust UTXO
           // belonging to that address. The SDK's selector treats the cache
           // as a hint about where balances live; the on-chain truth is
           // resolved at submit time, so any dust UTXO is a valid hint.


### PR DESCRIPTION
…rough proxy

Bundles four related espo-configuration fixes surfaced by a review of the `oyl.alkanode.com` / `api.alkanode.com` fallback surface that grew across PRs #108–#114.

## 1. queries/account.ts — route alkanode fallback through `/api/rpc/...`

The client-side alkanode REST fallback added in #112/#113 fetched `https://oyl.alkanode.com/get-alkanes-by-address` directly from the browser:
- Violates CLAUDE.md "no raw `fetch(rpc, …)` calls in app code".
- Depended on permissive third-party CORS at alkanode.
- Read `process.env.ESPO_MAINNET_FALLBACK_URL` from the browser, which silently returns `undefined` without `NEXT_PUBLIC_` — the env override never actually worked on the client.

Refactored `tryAlkanodeAlkaneBalances` → `tryRestAlkanesByAddress(network, address)` which POSTs to `/api/rpc/${network}/get-alkanes-by-address`. The proxy's existing 200-with-empty fallback (route.ts:404-439) transparently routes to alkanode when subfrost returns empty, reading `ESPO_MAINNET_FALLBACK_URL` server-side (single source of truth).

Both callers updated (`fetchAlkaneBalancesViaProtobuf`, `walletUtxoCacheQueryOptions`). SoT-1 trust contract preserved: alkanode only consulted when subfrost has zero data across all dust UTXOs.

## 2. lib/alkanes/rpc.ts + PoolDetailsCard.tsx — env knob for alkanode RPC

Hardcoded `https://api.alkanode.com/rpc` in two places (`getAllAmmPools` / `getPoolReserves` and the pizzafun series-id lookup) had no override. If alkanode goes down, those calls have no recourse. Other entry points all gained env knobs in #108–#113 — these were missed.

Added `NEXT_PUBLIC_ESPO_RPC_URL` (parallel to server-side `ESPO_RPC_PRIMARY_URL` in `app/api/amm-volume/route.ts`). Default unchanged.

## 3. app/api/token-names/route.ts — 200-with-empty fallback

The user reports `[useTokenNames] Loaded 0 token entries (0 priced)` on the swap page; pair pickers stall on numeric IDs (`2:0` instead of `DIESEL`) while subfrost returns valid HTTP 200 with empty `data.tokens: []` (indexer drift, same incident shape as #108/#111/#112/#113).

The existing route only fell back on network errors / non-2xx; the empty-200 shape slipped through and consumers got 0 tokens. Added the same empty-detection pattern as `app/api/pools/cached/route.ts:65-87`: when primary returns 0 tokens AND a fallback URL is configured, retry against alkanode and use its response if it has more tokens.

In-memory `fresh` / `lastGood` caches kept as-is — they handle the "both upstreams down for >5min" case which the CDN cache can't.

## 4. CLAUDE.md — flag the metashrew_height routing rule

PR #114 split mainnet metashrew routing: `metashrew_view` → /v6 (sticky, fast for fanout), `metashrew_height` → /v4 (gateway, no rate limit). The rule is load-bearing: SDK's `WebProvider::sync` polls `metashrew_height` every ~500ms for up to 30s, and /v6 rate-limits bursts (~7-8 calls in 3.5s = 429). Putting `metashrew_height` back on /v6 would cause every swap to fail during normal 1-block indexer-lag windows.

Added a "⚠️ DO NOT MOVE metashrew_height ONTO /v6" subsection to prevent a future "consistency" cleanup from re-introducing the regression.

## Tests

Two new vitest suites, 14 tests total:

- `queries/__tests__/alkane-balance-rest-fallback.test.ts` (8 tests): mocks the rpc layer + fetch, asserts the new function routes through `/api/rpc/{network}/get-alkanes-by-address`, never matches `alkanode.com`, fires only when documented signature holds (mainnet + dust UTXOs + zero aggregate), and handles fallback errors gracefully.

- `app/api/token-names/__tests__/empty-fallback.test.ts` (6 tests): mocks both upstreams, asserts empty-200 triggers fallback, non-empty primary skips fallback, both-empty returns empty without crashing, fallback throw is caught, non-mainnet skips fallback, price extraction works on fallback data.

Run: `npx vitest run queries/__tests__/alkane-balance-aggregation.test.ts queries/__tests__/alkane-balance-rest-fallback.test.ts app/api/token-names/__tests__/empty-fallback.test.ts` → 26/26 passed.