### PR TITLE
fix(swap+rpc): unblock mainnet swap quote + harden wallet UTXO cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,20 @@ Available helpers (canonical surface):
 
 When you next edit any of those files, swap the raw fetch for the corresponding `rpc.*` helper.
 
+### ⚠️ Mainnet metashrew routing — DO NOT MOVE `metashrew_height` ONTO /v6
+
+`app/api/rpc/[[...segments]]/route.ts` splits mainnet metashrew JSON-RPC traffic by method:
+
+| Method | Endpoint | Why |
+|--------|----------|-----|
+| `metashrew_view` | `/v6/subfrost` (sticky, fast) | 12–30× faster on the wallet UTXO prewarm fanout (parallel `alkanes_protorunesbyoutpoint`). |
+| `metashrew_height` | `/v4/subfrost` (gateway) | /v6 rate-limits aggressive bursts. The SDK's `WebProvider::sync` polls `metashrew_height` every ~500ms for up to 30s while waiting for the indexer to catch up to bitcoind, and reliably trips /v6's burst limit (429 after ~7-8 calls in ~3.5s). The 429 propagates as "Network error: HTTP error: 429" and the swap aborts. /v4 doesn't rate-limit and the single-call latency penalty is negligible. |
+| Everything else (`alkanes_*`, `bitcoin_*`, `esplora_*`) | `/v4/subfrost` | /v6 only serves metashrew JSON-RPC. |
+
+DO NOT consolidate `metashrew_height` back onto /v6 for "consistency" — the perf benefit is zero (single trivial call, no fanout) and the cost is total swap failure during normal 1-block indexer-lag windows (which happen every ~10 minutes on mainnet). Verified 2026-05-10 (commit `3d3b48eb`).
+
+**Note on REST sub-paths**: those (`/get-pool-details`, `/get-alkanes`, `/get-alkane-details`, etc.) are NOT routed through subfrost.io at all. Per flex (alkanes-rs maintainer, 2026-05-10): "All of the /v4/subfrost/* routes other than BTC pricing are espo routes. They should be bypassed and go directly to espo." REST sub-paths route to canon Espo on alkanode (`oyl.alkanode.com`) with no subfrost.io fallback. See `REST_PRIMARY_BASE_URLS` in the proxy and the route-specific files (`app/api/pools/cached`, `app/api/pools/stats`, `app/api/token-names`, `app/api/token-details`).
+
 ### Indexer Sync — Proactive Probe in `alkanesExecuteTyped`
 
 `lib/alkanes/execute.ts:alkanesExecuteTyped` calls `provider.waitForIndexer()` before dispatching to `alkanesExecuteWithStrings` / `alkanesExecuteFull`. This catches the transient `metashrew_height < bitcoind_blockcount` window on mainnet (sometimes a block apart for ~10–30s) up-front, instead of letting the SDK's internal 30s timeout fire and bury the swap on "Building Transaction".

--- a/app/api/amm-volume/route.ts
+++ b/app/api/amm-volume/route.ts
@@ -1,73 +1,132 @@
 /**
  * Total AMM Volume API — proxies espo's `ammdata.get_total_volume_amm`.
  *
- * GET /api/amm-volume?limit=<n>
+ * GET /api/amm-volume?limit=<n>&maxPages=<m>
  *
  * Returns cumulative AMM volume time-series in USD (post-scaling). The
  * upstream espo module emits values as scaled bigints (`scale` field, default
  * 1e16) so we divide here and return plain JS numbers — consumers don't need
  * to know about the fixed-point encoding.
  *
+ * ## Pagination
+ *
+ * Upstream returns points in forward chronological order starting from the
+ * oldest swap event. A single page of 1000 only covers ~4000 blocks (~28
+ * days). Without pagination the chart shows a flat line at last-page-value
+ * for ~9 months and then jumps to `latest` on today's bucket — exactly the
+ * "shoots straight up" symptom reported on staging 2026-05-10.
+ *
+ * We page forward until either (a) we've reached `latest.height`, or (b)
+ * we've hit `maxPages` (default 50, cap 200). Each page is one upstream
+ * call. The Vercel CDN caches the assembled series for 30s with SWR.
+ *
  * Upstream: https://api.alkanode.com/rpc method `ammdata.get_total_volume_amm`.
- * Override via env:
- *   ESPO_RPC_PRIMARY_URL    — primary JSON-RPC base. Default api.alkanode.com.
- *   ESPO_RPC_FALLBACK_URL   — fallback if primary fails. No default; set to
- *                             enable an alternate alkanode/subfrost host.
+ * Single upstream, no fallback (per flex 2026-05-11). Override the host via
+ * ESPO_RPC_URL if alkanode itself goes down.
  */
 
 import { NextResponse } from 'next/server';
 
-const ESPO_RPC_PRIMARY = process.env.ESPO_RPC_PRIMARY_URL || 'https://api.alkanode.com/rpc';
-const ESPO_RPC_FALLBACK = process.env.ESPO_RPC_FALLBACK_URL || '';
+const ESPO_RPC_PRIMARY =
+  process.env.ESPO_RPC_URL ||
+  process.env.ESPO_RPC_PRIMARY_URL ||
+  'https://api.alkanode.com/rpc';
 
 const UPSTREAM_TIMEOUT_MS = 8_000;
+const DEFAULT_MAX_PAGES = 50;
+const HARD_CAP_PAGES = 200;
 
 const FRESH_CACHE_HEADER = 'public, s-maxage=30, stale-while-revalidate=300';
+
+interface RawPoint { height: number | string; value: string | number; }
+interface RawResult {
+  ok?: boolean;
+  scale?: string | number;
+  unit?: string;
+  points?: RawPoint[];
+  latest?: { height: number | string; value: string | number };
+  has_more?: boolean;
+}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const limit = Math.min(Number(searchParams.get('limit') || 1000), 5000);
+  const maxPages = Math.min(
+    Number(searchParams.get('maxPages') || DEFAULT_MAX_PAGES),
+    HARD_CAP_PAGES,
+  );
 
-  const callRpc = async (url: string) => {
+  const callRpcPage = async (url: string, page: number): Promise<RawResult> => {
     const resp = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         jsonrpc: '2.0',
         method: 'ammdata.get_total_volume_amm',
-        params: { limit, page: 1 },
-        id: 1,
+        params: { limit, page },
+        id: page,
       }),
       signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
       cache: 'no-store',
     });
-    if (!resp.ok) throw new Error(`http ${resp.status} (${url})`);
+    if (!resp.ok) throw new Error(`http ${resp.status} (${url} page=${page})`);
     const j = await resp.json();
-    if (j?.error) throw new Error(`rpc error: ${JSON.stringify(j.error)}`);
-    if (!j?.result?.ok) throw new Error('rpc result not ok');
-    return j.result;
+    if (j?.error) throw new Error(`rpc error page=${page}: ${JSON.stringify(j.error)}`);
+    if (!j?.result?.ok) throw new Error(`rpc result not ok page=${page}`);
+    return j.result as RawResult;
   };
 
   try {
-    let result: any;
-    try {
-      result = await callRpc(ESPO_RPC_PRIMARY);
-    } catch (primaryErr) {
-      if (!ESPO_RPC_FALLBACK) throw primaryErr;
-      console.warn(`[amm-volume] primary failed (${primaryErr instanceof Error ? primaryErr.message : 'unknown'}); falling back to ${ESPO_RPC_FALLBACK}`);
-      result = await callRpc(ESPO_RPC_FALLBACK);
-    }
+    // Page 1 establishes the scale + latest anchor. Subsequent pages reuse
+    // the same scale (it's a per-result invariant set by the server's
+    // ammdata module). Single upstream — no fallback (per flex 2026-05-11:
+    // "we should never have more than 1 way to do something").
+    const activeUrl = ESPO_RPC_PRIMARY;
+    const result: RawResult = await callRpcPage(ESPO_RPC_PRIMARY, 1);
 
-    // Pre-divide by scale so consumers get plain JS numbers in USD.
     const scaleBigInt = BigInt(result.scale || '10000000000000000');
     const scaleFloat = Number(scaleBigInt);
 
-    const points = (result.points || [])
-      .map((p: any) => ({
+    const allRaw: RawPoint[] = [...(result.points || [])];
+    const latestHeight = result.latest ? Number(result.latest.height) : null;
+
+    // Walk forward until we cover the gap between the last point we have
+    // and `latest.height`. Stop when:
+    //   - server says no more pages
+    //   - we've reached or surpassed the latest anchor
+    //   - we've spent maxPages calls
+    //   - a page returns zero new points (defensive against server quirks)
+    let page = 2;
+    while (page <= maxPages) {
+      const lastHaveHeight = allRaw.length > 0
+        ? Number(allRaw[allRaw.length - 1]!.height)
+        : null;
+      if (
+        latestHeight != null
+        && lastHaveHeight != null
+        && lastHaveHeight >= latestHeight
+      ) break;
+      if (result.has_more === false) break;
+      let nextPage: RawResult;
+      try {
+        nextPage = await callRpcPage(activeUrl, page);
+      } catch (err) {
+        console.warn(`[amm-volume] page ${page} failed (${err instanceof Error ? err.message : 'unknown'}); stopping pagination at page ${page - 1}`);
+        break;
+      }
+      const newPts = nextPage.points || [];
+      if (newPts.length === 0) break;
+      allRaw.push(...newPts);
+      result.has_more = nextPage.has_more;
+      page += 1;
+    }
+
+    const points = allRaw
+      .map((p) => ({
         height: Number(p.height),
         valueUsd: Number(p.value) / scaleFloat,
       }))
-      .filter((p: any) => Number.isFinite(p.height) && Number.isFinite(p.valueUsd));
+      .filter((p) => Number.isFinite(p.height) && Number.isFinite(p.valueUsd));
 
     const latest = result.latest
       ? {
@@ -85,10 +144,11 @@ export async function GET(request: Request) {
       },
       { headers: { 'Cache-Control': FRESH_CACHE_HEADER } },
     );
-  } catch (e: any) {
-    console.error('[amm-volume] failed:', e?.message || e);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'fetch failed';
+    console.error('[amm-volume] failed:', msg);
     return NextResponse.json(
-      { ok: false, error: e?.message || 'fetch failed' },
+      { ok: false, error: msg },
       { status: 502 },
     );
   }

--- a/app/api/pools/cached/route.ts
+++ b/app/api/pools/cached/route.ts
@@ -14,16 +14,22 @@ const UPSTREAM_TIMEOUT_MS = 8_000;
 // far better than a per-process map ever could.
 const FRESH_CACHE_HEADER = 'public, s-maxage=30, stale-while-revalidate=300';
 
-// Fallback Espo deployment for /get-all-pools-details on mainnet. Same OYL
-// REST contract as subfrost.io; used when the primary upstream 5xx's. Set
-// `ESPO_MAINNET_FALLBACK_URL=""` to disable.
-const fallbackEnv = process.env.ESPO_MAINNET_FALLBACK_URL;
-const FALLBACK_BASE_URLS: Record<string, string> = {};
-if (fallbackEnv === undefined) {
-  FALLBACK_BASE_URLS.mainnet = 'https://oyl.alkanode.com';
-} else if (fallbackEnv.length > 0) {
-  FALLBACK_BASE_URLS.mainnet = fallbackEnv;
-}
+// Mainnet upstream: canon Espo on alkanode. Per flex (alkanes-rs maintainer,
+// 2026-05-10): "All of the /v4/subfrost/* routes other than BTC pricing are
+// espo routes. They should be bypassed and go directly to espo." We do not
+// keep a subfrost.io fallback because subfrost.io is the reverse proxy this
+// route is bypassing — falling back to it would re-introduce the broken
+// path (verified 2026-05-10: /v4/subfrost/get-alkane-details returns 404
+// alkane_not_found for known mainnet alkanes; /v4/subfrost/get-all-pools-details
+// returns total:0 during indexer drift).
+//
+// Override with ESPO_MAINNET_PRIMARY_URL if alkanode itself goes down.
+const ALKANODE_OYL_MAINNET = 'https://oyl.alkanode.com';
+const ESPO_BASE_URLS: Record<string, string> = {};
+const primaryEnv = process.env.ESPO_MAINNET_PRIMARY_URL;
+ESPO_BASE_URLS.mainnet = primaryEnv && primaryEnv.length > 0
+  ? primaryEnv
+  : ALKANODE_OYL_MAINNET;
 
 function getFactoryIdParts(network: string): { block: string; tx: string } {
   const cfg = getConfig(network) as { ALKANE_FACTORY_ID?: string };
@@ -36,59 +42,37 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const network = searchParams.get('network') || 'mainnet';
 
-  const baseUrl = SUBFROST_API_URLS[network];
+  // On mainnet: canon alkanode is the only upstream.
+  // On other networks: subfrost.io is the only available espo deployment.
+  const baseUrl = ESPO_BASE_URLS[network] || SUBFROST_API_URLS[network];
   if (!baseUrl) {
     return NextResponse.json({ error: `unknown network ${network}` }, { status: 400 });
   }
 
   const factoryParts = getFactoryIdParts(network);
-  const fallbackBase = FALLBACK_BASE_URLS[network];
 
-  const fetchPools = async (base: string) => {
-    const resp = await fetch(`${base}/get-all-pools-details`, {
+  try {
+    const resp = await fetch(`${baseUrl}/get-all-pools-details`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ factoryId: factoryParts }),
       signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
       cache: 'no-store',
     });
-    if (!resp.ok) throw new Error(`upstream ${resp.status} (${base})`);
-    return resp.json();
-  };
-
-  try {
-    let data: any;
-    try {
-      data = await fetchPools(baseUrl);
-
-      // Subfrost upstream sometimes returns 200 OK with `total: 0` even when
-      // pools exist (indexer drift, partial outage). On mainnet specifically,
-      // the alkanode mirror is authoritative — if primary returns suspiciously
-      // empty AND a fallback is configured, fall through to it.
-      const total = Number(data?.data?.total ?? 0);
-      if (fallbackBase && total === 0) {
-        console.warn(`[pools/cached] primary returned 0 pools (likely indexer drift); checking fallback ${fallbackBase}`);
-        try {
-          const fallbackData = await fetchPools(fallbackBase);
-          const fallbackTotal = Number(fallbackData?.data?.total ?? 0);
-          if (fallbackTotal > total) {
-            console.warn(`[pools/cached] fallback returned ${fallbackTotal} pools; using fallback data`);
-            data = fallbackData;
-          }
-        } catch (fallbackErr) {
-          // Fallback failed — keep primary's empty response rather than 502.
-          console.warn(`[pools/cached] fallback also failed: ${fallbackErr instanceof Error ? fallbackErr.message : 'unknown'}`);
-        }
-      }
-    } catch (primaryErr) {
-      if (!fallbackBase) throw primaryErr;
-      console.warn(`[pools/cached] primary failed (${primaryErr instanceof Error ? primaryErr.message : 'unknown'}); falling back to ${fallbackBase}`);
-      data = await fetchPools(fallbackBase);
+    if (!resp.ok) {
+      return NextResponse.json(
+        { error: `upstream ${resp.status} (${baseUrl})` },
+        { status: 502 },
+      );
     }
+    const data = await resp.json();
     return NextResponse.json(data, {
       headers: { 'Cache-Control': FRESH_CACHE_HEADER },
     });
-  } catch (e: any) {
-    return NextResponse.json({ error: e?.message || 'fetch failed' }, { status: 502 });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'fetch failed' },
+      { status: 502 },
+    );
   }
 }

--- a/app/api/pools/stats/route.ts
+++ b/app/api/pools/stats/route.ts
@@ -3,6 +3,26 @@ import { getConfig, SUBFROST_API_URLS } from '@/utils/getConfig';
 
 export const dynamic = 'force-dynamic';
 
+// Per flex (alkanes-rs maintainer, 2026-05-10): "All of the /v4/subfrost/*
+// routes other than BTC pricing are espo routes. They should be bypassed and
+// go directly to espo." Canon espo lives on alkanode for mainnet. Subfrost.io
+// is the reverse-proxy this route deliberately bypasses — no fallback to it,
+// because falling back would re-introduce the broken path the bypass exists
+// to avoid.
+//
+// Other networks (testnet/signet/regtest/etc.) only have a subfrost.io espo
+// deployment available, so they continue to use that. There is no canon
+// alkanode for non-mainnet espo.
+//
+// Override mainnet with ESPO_MAINNET_PRIMARY_URL if alkanode itself goes down.
+const ALKANODE_OYL_MAINNET = 'https://oyl.alkanode.com';
+function getEspoBase(network: string): string {
+  if (network === 'mainnet') {
+    return process.env.ESPO_MAINNET_PRIMARY_URL || ALKANODE_OYL_MAINNET;
+  }
+  return SUBFROST_API_URLS[network] || SUBFROST_API_URLS.mainnet;
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -140,7 +160,7 @@ export async function GET(request: NextRequest) {
     }
 
     const config = getConfig(network);
-    const apiUrl = SUBFROST_API_URLS[network] || SUBFROST_API_URLS.mainnet;
+    const apiUrl = getEspoBase(network);
     const [factoryBlock, factoryTx] = config.ALKANE_FACTORY_ID.split(':');
 
     // Fetch all pools via OylAPI REST endpoint (same pattern as @alkanes/ts-sdk OylApiClient)
@@ -154,9 +174,9 @@ export async function GET(request: NextRequest) {
 
     if (!response.ok) {
       const text = await response.text().catch(() => '');
-      console.error(`[API /pools/stats] Subfrost API error: ${response.status}`, text);
+      console.error(`[API /pools/stats] Espo API error (${apiUrl}): ${response.status}`, text);
       return NextResponse.json(
-        { success: false, error: `Subfrost API error: ${response.status}` },
+        { success: false, error: `Espo API error: ${response.status}` },
         { status: 502 },
       );
     }

--- a/app/api/rpc/[[...segments]]/route.ts
+++ b/app/api/rpc/[[...segments]]/route.ts
@@ -87,18 +87,31 @@ const BATCH_RPC_ENDPOINTS: Record<string, string> = {
   oylnet: 'https://regtest.subfrost.io/v4/jsonrpc',
 };
 
-// Fallback Espo REST host for mainnet — same OYL module contract as subfrost
-// (verified against /get-all-amm-tx-history, /get-all-pools-details, etc).
-// Used only for REST sub-path requests when the primary returns non-2xx, so
-// landing-page surfaces (Activity Feed, Trending Pair) survive Subfrost-side
-// Espo outages. Set `ESPO_MAINNET_FALLBACK_URL=""` to disable.
-const restFallbackEnv = process.env.ESPO_MAINNET_FALLBACK_URL;
-const REST_FALLBACK_BASE_URLS: Record<string, string> = {};
-if (restFallbackEnv === undefined) {
-  REST_FALLBACK_BASE_URLS.mainnet = 'https://oyl.alkanode.com';
-} else if (restFallbackEnv.length > 0) {
-  REST_FALLBACK_BASE_URLS.mainnet = restFallbackEnv;
-}
+// REST upstream for mainnet: canon Espo on alkanode. Per flex (alkanes-rs
+// maintainer, 2026-05-10):
+//   "All of the /v4/subfrost/* routes other than BTC pricing are espo routes.
+//    They should be bypassed and go directly to espo."
+//
+// Subfrost.io's /v4/subfrost/* hosting was verified broken on 2026-05-10
+// (404 alkane_not_found / 200-with-zero-pools for several REST endpoints),
+// which is why landing-page surfaces (Trending Pair, Markets TVL) stopped
+// showing real data on staging. We do NOT keep a subfrost.io fallback —
+// falling back to it would re-introduce that broken path.
+//
+// Override env: ESPO_MAINNET_PRIMARY_URL — pin a different mainnet upstream
+// (e.g. a backup alkanode mirror) if alkanode itself goes down.
+//
+// Note: this ONLY applies to REST sub-paths (e.g. /get-pool-details). The
+// JSON-RPC routing (metashrew_view, alkanes_*, esplora_*, bitcoin_*) is a
+// separate concern and stays on subfrost.io's gateway — see pickEndpoint
+// below. Splitting JSON-RPC primary is out of scope here because alkanode
+// hosts the espo REST contract but not the full subfrost JSON-RPC gateway.
+const ALKANODE_OYL_MAINNET = 'https://oyl.alkanode.com';
+const REST_PRIMARY_BASE_URLS: Record<string, string> = {};
+const restPrimaryEnv = process.env.ESPO_MAINNET_PRIMARY_URL;
+REST_PRIMARY_BASE_URLS.mainnet = restPrimaryEnv && restPrimaryEnv.length > 0
+  ? restPrimaryEnv
+  : ALKANODE_OYL_MAINNET;
 
 function pickEndpoint(body: any, network: string) {
   const isBatch = Array.isArray(body);
@@ -204,8 +217,14 @@ export async function POST(
           console.log(`[RPC Proxy] qubitcoin-regtest REST /${restPath.join('/')} → empty (no data API)`);
           return NextResponse.json({ statusCode: 200, data: [] });
         }
-        // REST sub-path: forward to backend base URL + rest path
-        const baseUrl = (RPC_ENDPOINTS[network] || RPC_ENDPOINTS.regtest).replace(/\/$/, '');
+        // REST sub-path: forward to canon Espo (alkanode on mainnet, per
+        // flex 2026-05-10) with subfrost.io as the configured fallback.
+        // For non-mainnet networks the primary stays on subfrost.io because
+        // alkanode hosts a mainnet espo deployment only.
+        const restPrimary = REST_PRIMARY_BASE_URLS[network]
+          || RPC_ENDPOINTS[network]
+          || RPC_ENDPOINTS.regtest;
+        const baseUrl = restPrimary.replace(/\/$/, '');
         restSubPath = restPath.join('/');
         targetUrl = `${baseUrl}/${restSubPath}`;
       } else {
@@ -311,36 +330,19 @@ export async function POST(
       signet: 'https://signet.subfrost.io/v4/jsonrpc',
     };
 
-    let response = await fetch(targetUrl, {
+    const response = await fetch(targetUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
 
-    // REST sub-path Espo fallback. When the primary upstream returns 5xx /
-    // non-JSON / connection error for a /get-* style request, retry against
-    // alkanode (or whatever ESPO_MAINNET_FALLBACK_URL is set to). JSON-RPC
-    // requests are unaffected — they have their own metashrew-unwrap
-    // fallback below and route to a different upstream.
-    const restFallbackBase = restSubPath ? REST_FALLBACK_BASE_URLS[network] : null;
-    if (restSubPath && restFallbackBase && !response.ok) {
-      const fallbackUrl = `${restFallbackBase.replace(/\/$/, '')}/${restSubPath}`;
-      console.warn(`[RPC Proxy] REST primary ${response.status} for /${restSubPath}; falling back to ${fallbackUrl}`);
-      try {
-        const fallbackResp = await fetch(fallbackUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-        });
-        if (fallbackResp.ok) {
-          response = fallbackResp;
-        } else {
-          console.warn(`[RPC Proxy] REST fallback also failed: ${fallbackResp.status}`);
-        }
-      } catch (fallbackErr) {
-        console.warn(`[RPC Proxy] REST fallback threw:`, fallbackErr);
-      }
-    }
+    // No REST sub-path fallback. The primary REST upstream (canon Espo on
+    // alkanode for mainnet, set in REST_PRIMARY_BASE_URLS above) is the
+    // single source of truth — falling back to subfrost.io would re-introduce
+    // the broken /v4/subfrost/* path this proxy exists to bypass per flex
+    // (alkanes-rs maintainer, 2026-05-10). The JSON-RPC metashrew-unwrap
+    // fallback below is unrelated and stays — that path is for the
+    // /v6/subfrost intermittent 408/502 retry on metashrew_* methods.
 
     // Read the response body once. Upstream is always JSON-RPC, but infrastructure
     // errors (nginx 502, rate limits, service unavailable) may return plain text or HTML.
@@ -394,22 +396,10 @@ export async function POST(
         console.warn(`[RPC Proxy] metashrew non-JSON fallback exhausted for ${body.method}; falling through to error response`);
       }
 
-      // For REST sub-paths, attempt the alkanode fallback as a last resort.
-      if (restSubPath && restFallbackBase) {
-        const fallbackUrl = `${restFallbackBase.replace(/\/$/, '')}/${restSubPath}`;
-        console.warn(`[RPC Proxy] REST primary returned non-JSON for /${restSubPath}; trying ${fallbackUrl}`);
-        try {
-          const fallbackResp = await fetch(fallbackUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body),
-          });
-          const fallbackText = await fallbackResp.text();
-          try {
-            return NextResponse.json(JSON.parse(fallbackText), { status: fallbackResp.status });
-          } catch { /* fall through to error response below */ }
-        } catch { /* fall through */ }
-      }
+      // No REST fallback. Per flex (alkanes-rs maintainer, 2026-05-10) the
+      // canon Espo (alkanode for mainnet) is the only upstream — falling
+      // back to subfrost.io would re-introduce the broken /v4/subfrost/*
+      // path this proxy exists to bypass.
       const snippet = responseText.slice(0, 200).replace(/<[^>]*>/g, '').trim(); // strip HTML tags
       console.error(`[RPC Proxy] Non-JSON upstream response (${response.status}) for ${method}: ${snippet}`);
       return NextResponse.json(
@@ -418,57 +408,12 @@ export async function POST(
       );
     }
 
-    // REST sub-path "200-with-empty" fallback. Subfrost espo intermittently
-    // returns successful HTTP 200 responses with empty data while it's
-    // catching up on indexing — but the alkanode mirror has the real data.
-    // The 5xx fallback above doesn't fire on 200, and consumers that don't
-    // implement their own emptiness check (which is most of them) silently
-    // shadow real data with empty data.
-    //
-    // Detect both common OYL-API empty shapes:
-    //   { data: { total: 0, ... } }         (paginated endpoints)
-    //   { data: [] }                         (list endpoints)
-    // For either, retry against the configured REST fallback (alkanode on
-    // mainnet) and use its response if it has more data than primary.
-    //
-    // Skipped if response is non-2xx or already-fallback'd (the 5xx path
-    // above already handled it) or if no REST fallback is configured.
-    if (
-      restSubPath &&
-      restFallbackBase &&
-      response.ok
-    ) {
-      const isEmpty = (parsed: any): boolean => {
-        const d = parsed?.data;
-        if (Array.isArray(d)) return d.length === 0;
-        if (typeof d?.total === 'number') return d.total === 0;
-        if (typeof d?.count === 'number') return d.count === 0;
-        return false;
-      };
-      if (isEmpty(data)) {
-        const fallbackUrl = `${restFallbackBase.replace(/\/$/, '')}/${restSubPath}`;
-        console.warn(`[RPC Proxy] REST primary returned empty for /${restSubPath} (likely indexer drift); checking ${fallbackUrl}`);
-        try {
-          const fallbackResp = await fetch(fallbackUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body),
-          });
-          if (fallbackResp.ok) {
-            const fallbackText = await fallbackResp.text();
-            try {
-              const fallbackParsed = JSON.parse(fallbackText);
-              if (!isEmpty(fallbackParsed)) {
-                console.warn(`[RPC Proxy] REST fallback ${fallbackUrl} returned non-empty data; using fallback`);
-                data = fallbackParsed;
-              }
-            } catch { /* fallback non-JSON; keep primary */ }
-          }
-        } catch (fallbackErr) {
-          console.warn(`[RPC Proxy] REST empty-fallback threw:`, fallbackErr);
-        }
-      }
-    }
+    // No REST sub-path "200-with-empty" fallback. Per flex (2026-05-10) the
+    // canon Espo (alkanode for mainnet) is the single source of truth — if
+    // it returns empty, the data is genuinely absent. Layering subfrost.io
+    // as a fallback would shadow real on-chain absence with stale-cache
+    // hits AND re-introduce the broken /v4/subfrost/* path this proxy is
+    // bypassing.
 
     // Retry on metashrew-unwrap errors — fallback to /v4/jsonrpc which routes correctly
     if (data?.error?.message?.includes('metashrew-unwrap') && network && FALLBACK_ENDPOINTS[network]) {

--- a/app/api/token-details/route.ts
+++ b/app/api/token-details/route.ts
@@ -1,17 +1,30 @@
 /**
- * Token Details API — Proxies the data API's /get-alkane-details endpoint
+ * Token Details API — Proxies the canon Espo /get-alkane-details endpoint
  *
  * POST /api/token-details
  * Body: { alkaneIds: ["2:25720", "2:21219"], network?: string }
  *
- * Returns metadata for specific tokens not covered by the bulk /get-alkanes fetch.
- * This proxy avoids CORS issues when fetching directly from subfrost API.
+ * Returns metadata for specific tokens not covered by the bulk /get-alkanes
+ * fetch. This proxy avoids CORS issues when fetching directly from canon Espo.
+ *
+ * ## Routing policy (per flex, alkanes-rs maintainer, 2026-05-10)
+ *
+ * Mainnet PRIMARY: canon Espo on alkanode (oyl.alkanode.com) — verified
+ *   2026-05-10 to return real per-token name+symbol+holders+price for any
+ *   alkane id (e.g. 2:69 → name="FARTANE" symbol="H2S").
+ * Subfrost.io's /v4/subfrost/get-alkane-details was verified broken on
+ *   2026-05-10 (returns 404 alkane_not_found for known alkanes), which is
+ *   why this route stopped serving useful data on staging.
+ *
+ * Override with ESPO_MAINNET_PRIMARY_URL env var if alkanode goes down.
  */
 
 import { NextResponse } from 'next/server';
 
+const ALKANODE_OYL_MAINNET = 'https://oyl.alkanode.com';
+
 const RPC_ENDPOINTS: Record<string, string> = {
-  mainnet: 'https://mainnet.subfrost.io/v4/subfrost',
+  mainnet: process.env.ESPO_MAINNET_PRIMARY_URL || ALKANODE_OYL_MAINNET,
   testnet: 'https://testnet.subfrost.io/v4/subfrost',
   signet: 'https://signet.subfrost.io/v4/subfrost',
   regtest: 'https://regtest.subfrost.io/v4/subfrost',

--- a/app/api/token-names/route.ts
+++ b/app/api/token-names/route.ts
@@ -1,37 +1,35 @@
 /**
- * Token Names API — Proxies the data API's /get-alkanes endpoint
+ * Token Names API — Proxies the canon Espo /get-alkanes endpoint
  *
  * GET /api/token-names?network=<network>&limit=<limit>
  *
  * Returns a map of alkaneId → { name, symbol } for the top N tokens.
- * This proxy avoids CORS issues when fetching directly from subfrost API.
+ * This proxy avoids CORS issues when fetching directly from canon Espo.
  *
- * ## Env-configurable Espo upstreams (mainnet only)
+ * ## Routing policy (per flex, alkanes-rs maintainer, 2026-05-10)
  *
- * Both default to sensible values, override only when ops needs to flip
- * the active deployment without a code change. Examples:
+ * "All of the /v4/subfrost/* routes other than BTC pricing are espo routes.
+ *  They should be bypassed and go directly to espo."
  *
- *   ESPO_MAINNET_PRIMARY_URL   — primary base URL for /get-alkanes.
- *                                Default: https://mainnet.subfrost.io/v4/subfrost
- *                                Set to https://oyl.alkanode.com to use
- *                                alkanode as primary while subfrost's
- *                                hosted Espo is down.
- *   ESPO_MAINNET_FALLBACK_URL  — fallback used when the primary returns
- *                                non-2xx / times out. Default:
- *                                https://oyl.alkanode.com
- *                                Set empty string to disable fallback.
+ * Mainnet upstream: canon Espo on alkanode (oyl.alkanode.com). No fallback —
+ * falling back to subfrost.io would re-introduce the broken /v4/subfrost/*
+ * path this route exists to bypass (verified 2026-05-10: subfrost.io's
+ * /v4/subfrost/get-alkane-details returns 404 alkane_not_found for known
+ * mainnet alkanes).
  *
- * Non-mainnet networks (testnet/signet/regtest/etc) ignore these vars
- * since alkanode only hosts a mainnet Espo deployment.
+ * Override env var:
+ *   ESPO_MAINNET_PRIMARY_URL   — override mainnet upstream. Default alkanode.
+ *
+ * Non-mainnet networks (testnet/signet/regtest/etc) go through subfrost.io
+ * because alkanode hosts a mainnet Espo deployment only.
  */
 
 import { NextResponse } from 'next/server';
 
-const SUBFROST_MAINNET = 'https://mainnet.subfrost.io/v4/subfrost';
 const ALKANODE_OYL_MAINNET = 'https://oyl.alkanode.com';
 
 const RPC_ENDPOINTS: Record<string, string> = {
-  mainnet: process.env.ESPO_MAINNET_PRIMARY_URL || SUBFROST_MAINNET,
+  mainnet: process.env.ESPO_MAINNET_PRIMARY_URL || ALKANODE_OYL_MAINNET,
   testnet: 'https://testnet.subfrost.io/v4/subfrost',
   signet: 'https://signet.subfrost.io/v4/subfrost',
   regtest: 'https://regtest.subfrost.io/v4/subfrost',
@@ -41,22 +39,10 @@ const RPC_ENDPOINTS: Record<string, string> = {
   devnet: 'http://localhost:18888', // In-browser only
 };
 
-// Fallback Espo deployments hosted by alkanode — same OYL module + same REST
-// shape, so when the primary subfrost gateway has an Espo outage (verified
-// 2026-05-08, espo dev confirmed it's a Subfrost-side ops issue), the proxy
-// can degrade to this without any consumer-visible change. Mainnet only —
-// alkanode does not host testnet/signet/regtest Espo deployments.
-//
-// `ESPO_MAINNET_FALLBACK_URL=""` disables fallback entirely (single-upstream
-// mode). Any other value overrides the default alkanode URL.
-const fallbackEnv = process.env.ESPO_MAINNET_FALLBACK_URL;
-const FALLBACK_BASE_URLS: Record<string, string> = {};
-if (fallbackEnv === undefined) {
-  FALLBACK_BASE_URLS.mainnet = ALKANODE_OYL_MAINNET;
-} else if (fallbackEnv.length > 0) {
-  FALLBACK_BASE_URLS.mainnet = fallbackEnv;
-}
-// fallbackEnv === '' → no mainnet fallback (intentional opt-out)
+// No mainnet fallback (single-upstream by design). Falling back to subfrost.io
+// would re-introduce the broken /v4/subfrost/* path this route exists to
+// bypass. If alkanode goes down, override the primary via
+// ESPO_MAINNET_PRIMARY_URL instead of layering a fallback on top.
 
 /**
  * Well-known devnet token names — returned directly when network=devnet
@@ -108,10 +94,11 @@ export async function GET(request: Request) {
   }
 
   const baseUrl = RPC_ENDPOINTS[network] || RPC_ENDPOINTS.mainnet;
-  const fallbackBase = FALLBACK_BASE_URLS[network];
 
-  // Try primary; if it 502s / times out / errors, try the alkanode-hosted
-  // Espo as a fallback. Both expose the same `/get-alkanes` REST contract.
+  // Single upstream: canon Espo on alkanode for mainnet (no subfrost.io
+  // fallback — that's the route this proxy is bypassing). Other networks
+  // hit their respective subfrost.io espo deployment because alkanode hosts
+  // a mainnet espo only.
   const fetchAlkanes = async (base: string) => {
     const resp = await fetch(`${base}/get-alkanes`, {
       method: 'POST',
@@ -127,14 +114,7 @@ export async function GET(request: Request) {
   };
 
   try {
-    let response: Response;
-    try {
-      response = await fetchAlkanes(baseUrl);
-    } catch (primaryErr) {
-      if (!fallbackBase) throw primaryErr;
-      console.warn(`[token-names] primary upstream failed (${primaryErr instanceof Error ? primaryErr.message : 'unknown'}); falling back to ${fallbackBase}`);
-      response = await fetchAlkanes(fallbackBase);
-    }
+    const response = await fetchAlkanes(baseUrl);
 
     const data = await response.json();
     const tokens: any[] = data?.data?.tokens || [];

--- a/app/components/CumulativeAmmVolume.tsx
+++ b/app/components/CumulativeAmmVolume.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useTheme } from '@/context/ThemeContext';
 import { useAmmTotalVolume, type AmmVolumePoint } from '@/hooks/useAmmTotalVolume';
+import { fillDailyForward } from '@/lib/amm/volumeSeries';
 
 const ASSUMED_SECONDS_PER_BLOCK = 600;
 
@@ -14,13 +15,20 @@ function formatUsd(value: number): string {
 }
 
 /**
- * Convert sparse (height, valueUsd) points into a sorted, dedup'd
- * (time, value) series suitable for lightweight-charts.
+ * Convert sparse (height, valueUsd) points into a dense, sorted (time, value)
+ * series suitable for lightweight-charts.
  *
- * Espo only emits per-block-event points (no timestamps), so we estimate
- * each point's time by anchoring the latest point to "now" and walking
- * backward at 600s/block. Drift over a 30-day window is small enough for
- * a marketing-quality landing-page chart; precision isn't the goal.
+ * Espo only emits per-block-event points (no timestamps and gaps for blocks
+ * with no swap activity), so we estimate each point's time by anchoring the
+ * latest point to "now" and walking backward at 600s/block. Drift over a
+ * multi-month window is small enough for a marketing-quality landing-page
+ * chart; precision isn't the goal.
+ *
+ * After bucketing per UTC date, `fillDailyForward` carries the most-recent
+ * cumulative value forward into every otherwise-empty UTC day. Without this,
+ * a multi-month low-volume gap rendered as a single straight segment between
+ * the two outer points (the user-reported "August 2025 → today" symptom on
+ * staging, 2026-05-10).
  */
 function pointsToSeries(
   points: AmmVolumePoint[],
@@ -55,9 +63,15 @@ function pointsToSeries(
     }
   }
 
-  return Array.from(byDate.entries())
+  const sparse = Array.from(byDate.entries())
     .map(([time, value]) => ({ time, value }))
     .sort((a, b) => (a.time < b.time ? -1 : a.time > b.time ? 1 : 0));
+
+  // Densify: one point per UTC day from first → today, missing days inherit
+  // the most-recent prior value. Cumulative volume is monotonic so this is
+  // semantically correct (carry-forward = "no new activity that day").
+  const today = new Date(anchorMs).toISOString().slice(0, 10);
+  return fillDailyForward(sparse, today);
 }
 
 export default function CumulativeAmmVolume() {

--- a/app/components/TrendingPairs.tsx
+++ b/app/components/TrendingPairs.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import Link from 'next/link';
 import { usePools } from '@/hooks/usePools';
 import { useAllPoolStats } from '@/hooks/usePoolData';
+import { pickPositive } from '@/lib/pools/mergeStats';
 import TokenIcon from '@/app/components/TokenIcon';
 import HomeMarketsButton from '@/app/components/HomeMarketsButton';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -60,14 +61,18 @@ export default function TrendingPairs() {
       }
     }
 
-    // Merge stats with pools (usePools already provides TVL/volume from OYL Alkanode)
+    // Merge stats with pools (usePools already provides TVL/volume from OYL Alkanode).
+    // pickPositive (not `||`) so a `0` from the primary source doesn't
+    // short-circuit the stats overlay — the user-reported staging symptom
+    // (DIESEL/frBTC TVL=$0 → wrong trending pair selected) was caused by
+    // that exact bug. See lib/pools/mergeStats.ts header for context.
     const enrichedPools = filtered.map(p => {
       const stats = statsMap.get(p.id);
       return {
         ...p,
-        tvlUsd: p.tvlUsd || stats?.tvlUsd || 0,
-        vol24hUsd: p.vol24hUsd || stats?.volume24hUsd || 0,
-        vol30dUsd: p.vol30dUsd || stats?.volume30dUsd || 0,
+        tvlUsd: pickPositive(p.tvlUsd, stats?.tvlUsd),
+        vol24hUsd: pickPositive(p.vol24hUsd, stats?.volume24hUsd),
+        vol30dUsd: pickPositive(p.vol30dUsd, stats?.volume30dUsd),
       };
     });
 

--- a/app/swap/SwapShell.tsx
+++ b/app/swap/SwapShell.tsx
@@ -20,6 +20,7 @@ import { useFeeRate } from "@/hooks/useFeeRate";
 import { useBtcPrice } from "@/hooks/useBtcPrice";
 import { usePools } from "@/hooks/usePools";
 import { useAllPoolStats } from "@/hooks/usePoolData";
+import { pickPositive } from "@/lib/pools/mergeStats";
 import { useModalStore } from "@/stores/modals";
 import BigNumber from 'bignumber.js';
 import { useWrapMutation } from "@/hooks/useWrapMutation";
@@ -113,14 +114,20 @@ export default function SwapShell() {
     return basePools.map(pool => {
       const stats = statsMap.get(pool.id);
 
+      // pickPositive (not `||`) so a `0` from the primary `pool` doesn't
+      // short-circuit the stats overlay. Same rationale as TrendingPairs —
+      // see lib/pools/mergeStats.ts header. The token0/token1 split keeps
+      // its existing fallback to `pool.tvlUsd / 2` for symmetry, but uses
+      // pickPositive on the merged tvl too.
+      const mergedTvl = pickPositive(pool.tvlUsd, stats?.tvlUsd);
       return {
         ...pool,
-        tvlUsd: pool.tvlUsd || stats?.tvlUsd || 0,
-        token0TvlUsd: pool.token0TvlUsd || stats?.tvlToken0 || (pool.tvlUsd || 0) / 2,
-        token1TvlUsd: pool.token1TvlUsd || stats?.tvlToken1 || (pool.tvlUsd || 0) / 2,
-        vol24hUsd: pool.vol24hUsd || stats?.volume24hUsd || 0,
-        vol30dUsd: pool.vol30dUsd || stats?.volume30dUsd || 0,
-        apr: pool.apr || stats?.apr || 0,
+        tvlUsd: mergedTvl,
+        token0TvlUsd: pickPositive(pool.token0TvlUsd, stats?.tvlToken0, mergedTvl / 2),
+        token1TvlUsd: pickPositive(pool.token1TvlUsd, stats?.tvlToken1, mergedTvl / 2),
+        vol24hUsd: pickPositive(pool.vol24hUsd, stats?.volume24hUsd),
+        vol30dUsd: pickPositive(pool.vol30dUsd, stats?.volume30dUsd),
+        apr: pickPositive(pool.apr, stats?.apr),
       } as PoolSummary;
     });
   }, [poolsData?.items, poolStats]);
@@ -1477,7 +1484,17 @@ export default function SwapShell() {
     }
 
     // Default AMM swap (frBTC/DIESEL or other alkane pairs)
-    if (!quote) return;
+    // DIAGNOSTIC 2026-05-11: log when click is silently dropped because the
+    // quote engine hasn't produced a quote yet. Symptom: user reports "click
+    // does nothing, no logs, hangs forever" — the quote was still computing
+    // when they clicked, the function returned silently, and there was no
+    // user-visible signal of why. Should be replaced with a real CTA-disable
+    // (`!quote` should grey out the button until the quote is ready).
+    if (!quote) {
+      console.warn('[SWAP] handleSwap fired but quote is undefined — quote still computing or failed. fromToken:', fromToken, 'toToken:', toToken, 'fromAmount:', fromAmount, 'toAmount:', toAmount, 'isCalculating:', isCalculating);
+      showSwapError(t('errors.poolNotFound'));
+      return;
+    }
 
     // Validate that we have either a poolId (direct swap) or a route (multi-hop swap).
     // Multi-hop swaps use the factory's opcode 13 with a token path, not a single poolId.

--- a/app/swap/components/PoolDetailsCard.tsx
+++ b/app/swap/components/PoolDetailsCard.tsx
@@ -14,7 +14,12 @@ type Props = {
   bare?: boolean;
 };
 
-const ALKANODE_RPC_URL = 'https://api.alkanode.com/rpc';
+// Override via `NEXT_PUBLIC_ESPO_RPC_URL` if alkanode is unreachable. See
+// `lib/alkanes/rpc.ts` for the parallel definition. (Pattern ported from
+// PR #115 on subfrost/subfrost-app, 2026-05-11.)
+const ALKANODE_RPC_URL =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_ESPO_RPC_URL) ||
+  'https://api.alkanode.com/rpc';
 
 /**
  * Resolve the pizza.fun series ID (symbol) for a given alkane ID.

--- a/hooks/usePools.ts
+++ b/hooks/usePools.ts
@@ -11,7 +11,7 @@ import { getConfig, getRpcUrl } from '@/utils/getConfig';
 import { useAlkanesSDK } from '@/context/AlkanesSDKContext';
 import { KNOWN_TOKENS } from '@/lib/alkanes-client';
 import { simulateContract, extractField3Data, parseU128LE } from '@/lib/fujin/rpc';
-import { fetchCuratedPoolsListItems } from '@/lib/alkanes/curated-pools';
+import { getCuratedPoolsListItems } from '@/lib/alkanes/curated-pools';
 import { queryKeys } from '@/queries/keys';
 
 export type UsePoolsParams = {
@@ -730,23 +730,21 @@ export function usePools(params: UsePoolsParams = {}) {
         return { items, total: items.length };
       }
 
-      // Mainnet (and signet/testnet) primary: prefetch curated pool IDs
-      // directly from on-chain via metashrew. Espo + SDK fallbacks have been
-      // returning empty for extended periods (verified 2026-05-03), so we
-      // anchor the swap/LP UI on a known good list of pool IDs and fetch
-      // their live reserves with a single fan-out of opcode-999 calls.
-      // The remaining espo / SDK fallbacks below run *additively* — any
-      // extra pools they surface get layered on top of the curated set.
-      if (network === 'mainnet' || network === 'signet' || network === 'testnet') {
-        try {
-          const rpcUrl = getRpcUrl(network);
-          const curated = await fetchCuratedPoolsListItems(rpcUrl);
-          if (curated.length > 0) {
-            items = curated;
-          }
-        } catch (e) {
-          console.warn('[usePools] curated pool prefetch failed:', e);
-        }
+      // Mainnet: ONLY the static curated pool list. No discovery phase.
+      //
+      // Per flex (alkanes-rs maintainer, 2026-05-11):
+      //   "There shouldn't be a pool discovery phase at all"
+      //   "We have hardcoded pools in there now"
+      //
+      // Returns synchronously — `getCuratedPoolsListItems()` is a pure
+      // constructor over `MAINNET_CURATED_POOLS`, no network call. If we
+      // need to add/remove a pool, edit `lib/alkanes/curated-pools.ts`.
+      // Live reserves for these pools are fetched separately by the swap
+      // quote engine via `usePoolStateLive`; that's a price-math concern,
+      // not pool discovery.
+      if (network === 'mainnet') {
+        items = getCuratedPoolsListItems();
+        return { items, total: items.length };
       }
 
       // Merge fallback pool entries onto the curated set instead of replacing

--- a/hooks/useSwapQuotes.ts
+++ b/hooks/useSwapQuotes.ts
@@ -30,7 +30,7 @@
  * @see useAlkanesTokenPairs.ts - Pool data fetching
  * @see constants/index.ts - Documentation on factory vs pool opcodes
  */
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { useDebounce } from 'use-debounce';
@@ -142,6 +142,9 @@ async function calculateSwapPrice(
   const amountInAlks = toAlks(amount);
   const amountNumeric = parseFloat(amount);
   if (!amount || !Number.isFinite(amountNumeric) || amountNumeric === 0) {
+    // poolId carried so a click-without-amount doesn't trigger the
+    // "swapFailedPoolNotFound" toast — the pool was found, the user
+    // just hasn't typed an amount yet.
     return {
       direction,
       inputAmount: amount,
@@ -154,6 +157,7 @@ async function calculateSwapPrice(
       displaySellAmount: '0',
       displayMinimumReceived: '0',
       displayMaximumSent: '0',
+      poolId: (() => { const [b, t] = pool.id.split(':'); return { block: b, tx: t }; })(),
     } as SwapQuote;
   }
 
@@ -170,7 +174,10 @@ async function calculateSwapPrice(
   //
   // If `liveState` isn't available yet (in-flight, errored, or disabled),
   // return a zero quote so the UI can show "Loading…" / disable the
-  // swap button. Anything else is silently wrong.
+  // swap button. The early-return MUST still carry `poolId` so the
+  // SwapShell click handler's `quote.poolId` guard doesn't spuriously
+  // surface "swapFailedPoolNotFound" — we found the pool, the live
+  // reserves are just still in flight.
   if (!liveState) {
     return {
       direction,
@@ -185,6 +192,7 @@ async function calculateSwapPrice(
       displayMinimumReceived: '0',
       displayMaximumSent: '0',
       reservesUnavailable: true,
+      poolId: (() => { const [b, t] = pool.id.split(':'); return { block: b, tx: t }; })(),
     } as SwapQuote;
   }
   // Chain-aware reserves: replay our pending swaps targeting this
@@ -310,6 +318,30 @@ export function useSwapQuotes(
       (p.token0.id === buyCurrencyId && p.token1.id === sellCurrencyId),
     );
   }, [sellPairs, sellCurrencyId, buyCurrencyId]);
+
+  // DIAGNOSTIC 2026-05-11: trace what the engine is seeing when no quote
+  // populates. This logs once per change in the lookup state — not on every
+  // render — so the console isn't spammed.
+  useEffect(() => {
+    if (!poolsData?.items) return;
+    if (!sellCurrencyId || !buyCurrencyId) return;
+    const sellMatch = sellPairs?.length ?? 0;
+    const buyMatch = buyPairs?.length ?? 0;
+    if (directPool) {
+      console.log(
+        `[useSwapQuotes] direct pool found: id=${directPool.id} ` +
+        `token0=${directPool.token0.id} token1=${directPool.token1.id} ` +
+        `(looking for sellId=${sellCurrencyId} buyId=${buyCurrencyId})`,
+      );
+    } else {
+      const head = poolsData.items.slice(0, 5).map(p => `${p.id}[${p.token0.id}/${p.token1.id}]`);
+      console.warn(
+        `[useSwapQuotes] direct pool NOT FOUND for sellId=${sellCurrencyId} buyId=${buyCurrencyId}; ` +
+        `sellPairs=${sellMatch} buyPairs=${buyMatch} totalPools=${poolsData.items.length}; ` +
+        `first5 = ${head.join(', ')}`,
+      );
+    }
+  }, [poolsData, sellPairs, buyPairs, sellCurrencyId, buyCurrencyId, directPool]);
 
   // Live reserves for the direct pool. Only polls while the user has typed an
   // amount (avoids background traffic when the swap form is idle). HeightPoller

--- a/lib/alkanes/curated-pools.ts
+++ b/lib/alkanes/curated-pools.ts
@@ -1,29 +1,36 @@
 /**
- * Curated mainnet pool list — known good IDs verified on-chain.
+ * Curated mainnet pool list — fully static, NO runtime discovery.
  *
- * The espo `/get-all-pools-details` and `/get-all-token-pairs` endpoints have
- * been returning empty on mainnet for an extended period (see audit
- * 2026-05-02 + bug report 2026-05-03). The SDK's
- * `alkanesGetAllPoolsWithDetails` fallback also misses several pools.
- * Without a pool list, the swap form's "Select Token to Receive" modal
- * filters out every BTC-paired token because no pool matches BTC's
- * counterparty (frBTC).
+ * Per flex (alkanes-rs maintainer, 2026-05-11):
+ *   "There shouldn't be a pool discovery phase at all"
+ *   "We have hardcoded pools in there now" — "Right"
+ *   "Even if we didn't, that's the migration from subfrost api to espo we
+ *    maybe haven't done yet"
  *
- * This module hardcodes the mainnet pool IDs we want to surface in the
- * UI, fetches their *live* reserves directly via metashrew_view simulate
- * (opcode 999 PoolDetails), and assembles a `PoolsListItem[]` shaped
- * identically to what `usePools` returns from the espo path. Plug it in
- * as a high-priority data source and the swap/LP forms light up
- * immediately.
+ * Implementation rules:
+ *   - The pool list is a TypeScript constant. It does not depend on any
+ *     network call to enumerate. usePools / useSwapQuotes can synchronously
+ *     ask "what pools exist?" and get an answer in zero ms with zero
+ *     failure modes.
+ *   - Each entry encodes everything the UI needs to find the pool: the
+ *     pool's alkane id, the non-frBTC token's alkane id, display strings,
+ *     and the LP-token alkane id (for wallet enumeration).
+ *   - Live RESERVES are still fetched on-demand by the swap quote engine
+ *     (`fetchLivePoolState` / `usePoolStateLive`) — that's a different
+ *     concern (price math), not pool discovery. Reserves change every
+ *     block; pool existence does not.
+ *   - To add a pool: append an entry below. To remove a pool: delete an
+ *     entry. Never write code that "discovers" pools at runtime.
  *
  * Pool IDs were captured from a live mainnet `factory.GetAllPools` query
- * on 2026-05-03 against block 947661. They are stable: pools cannot be
- * renamed or moved, so as long as the AMM factory at 4:65522 keeps
- * returning these pools they remain valid.
+ * on 2026-05-03 against block 947661 and stay valid forever — pools are
+ * immutable on-chain.
  */
 
 import type { PoolsListItem } from '@/hooks/usePools';
-import { simulateContract, extractField3Data, parseU128LE } from '@/lib/fujin/rpc';
+
+const FRBTC_ID = '32:0';
+const MAINNET_FACTORY_ID = '4:65522';
 
 /**
  * Mainnet alkane id ↔ symbol/name + its direct frBTC pool. Each entry
@@ -32,152 +39,89 @@ import { simulateContract, extractField3Data, parseU128LE } from '@/lib/fujin/rp
  * automatically (BTC → wrap to frBTC → swap to target).
  */
 export interface CuratedPool {
+  /** Pool id (block:tx) — must contain `tokenId` and frBTC (32:0). */
+  poolId: string;
   /** Alkane id of the non-frBTC token (the "counterparty" the user buys). */
   tokenId: string;
-  /** Display symbol (matches the contract's GET_SYMBOL output). */
+  /** Display symbol. */
   symbol: string;
   /** Display name. */
   name: string;
-  /** Pool id (block:tx) — must contain `tokenId` and frBTC (32:0). */
-  poolId: string;
+  /** Token decimals (8 for all known mainnet alkanes today). */
+  decimals: number;
+  /**
+   * Alkane id of the LP token issued by this pool (for wallet enumeration —
+   * lets the wallet card recognize "this dust outpoint is an LP receipt"
+   * without needing to call the pool contract).
+   */
+  lpTokenId?: string;
 }
 
 export const MAINNET_CURATED_POOLS: readonly CuratedPool[] = [
-  { tokenId: '2:0',     symbol: 'DIESEL',    name: 'DIESEL',    poolId: '2:77087' },
-  { tokenId: '2:25720', symbol: 'MIST',      name: 'ALKAMIST',  poolId: '2:77237' },
-  { tokenId: '2:590',   symbol: '🐝',         name: 'Bee',        poolId: '2:77220' },
-  { tokenId: '2:35275', symbol: 'DUST',      name: 'GOLD DUST', poolId: '2:77228' },
+  {
+    poolId: '2:77087',
+    tokenId: '2:0',
+    symbol: 'DIESEL',
+    name: 'DIESEL',
+    decimals: 8,
+  },
+  {
+    poolId: '2:77237',
+    tokenId: '2:25720',
+    symbol: 'MIST',
+    name: 'ALKAMIST',
+    decimals: 8,
+  },
+  {
+    poolId: '2:77220',
+    tokenId: '2:590',
+    symbol: '🐝',
+    name: 'Bee',
+    decimals: 8,
+  },
+  {
+    poolId: '2:77228',
+    tokenId: '2:35275',
+    symbol: 'DUST',
+    name: 'GOLD DUST',
+    decimals: 8,
+  },
 ] as const;
 
-/** Decode a u32 LE from a hex string at a hex-character offset. */
-function parseU32LE(hexData: string, offset: number): number {
-  const bytes = hexData.slice(offset, offset + 8);
-  if (bytes.length !== 8) return 0;
-  let value = 0;
-  for (let i = 0; i < 4; i++) {
-    const byte = parseInt(bytes.slice(i * 2, i * 2 + 2), 16);
-    if (!isNaN(byte)) value |= byte << (i * 8);
-  }
-  return value >>> 0;
-}
-
-function hexToUtf8(hex: string): string {
-  let out = '';
-  for (let i = 0; i + 1 < hex.length; i += 2) {
-    const byte = parseInt(hex.slice(i, i + 2), 16);
-    if (Number.isNaN(byte) || byte === 0) break;
-    out += String.fromCharCode(byte);
-  }
-  return out;
-}
-
 /**
- * Live reserves for a single curated pool. Calls the pool contract
- * directly via metashrew_view simulate opcode 999 (PoolDetails) — same
- * mechanism poolState.ts uses for swap quote inputs, so reserves are
- * always consistent with what the factory contract sees at submit time.
- */
-export interface CuratedPoolDetails {
-  poolId: string;
-  token0Id: string;
-  token1Id: string;
-  reserve0: string;
-  reserve1: string;
-  totalSupply: string;
-  name: string;
-}
-
-async function fetchCuratedPoolDetails(
-  rpcUrl: string,
-  poolId: string,
-): Promise<CuratedPoolDetails | null> {
-  let detailsHex: string;
-  try {
-    detailsHex = await simulateContract(rpcUrl, poolId, 999);
-  } catch (err) {
-    console.warn(`[curated-pools] opcode-999 failed for ${poolId}:`, err);
-    return null;
-  }
-  const poolInfo = extractField3Data(detailsHex, 116);
-  if (!poolInfo || poolInfo.length < 232) return null;
-
-  const token0Block = parseU128LE(poolInfo, 0);
-  const token0Tx = parseU128LE(poolInfo, 32);
-  const token1Block = parseU128LE(poolInfo, 64);
-  const token1Tx = parseU128LE(poolInfo, 96);
-  const reserve0 = parseU128LE(poolInfo, 128);
-  const reserve1 = parseU128LE(poolInfo, 160);
-  const totalSupply = parseU128LE(poolInfo, 192);
-  const nameLength = parseU32LE(poolInfo, 224);
-  const nameStart = 232;
-  const nameEnd = Math.min(nameStart + nameLength * 2, poolInfo.length);
-  const name = hexToUtf8(poolInfo.slice(nameStart, nameEnd));
-
-  return {
-    poolId,
-    token0Id: `${token0Block}:${token0Tx}`,
-    token1Id: `${token1Block}:${token1Tx}`,
-    reserve0: reserve0.toString(),
-    reserve1: reserve1.toString(),
-    totalSupply: totalSupply.toString(),
-    name,
-  };
-}
-
-/**
- * Render the curated list as `PoolsListItem[]` so it slots into the
- * existing `usePools` consumer surface (same shape `useAlkanesTokenPairs`
- * etc. already consume from the espo path).
+ * Convert the static curated list to `PoolsListItem[]` for `usePools`
+ * consumers (TrendingPairs, MarketsGrid, useSwapQuotes' `directPool`
+ * lookup, etc.). Synchronous — no fetch, no Promise, no failure modes.
  *
- * Promise.all-fetches reserves for every pool in parallel; takes
- * ~100-200ms on warm metashrew. If any individual pool fetch fails it's
- * skipped (logged) — the rest still surface.
+ * Reserves (`token0Amount`, `token1Amount`), TVL, volume, APR are
+ * intentionally undefined here. The swap quote engine fetches live
+ * reserves separately via `usePoolStateLive` (opcode-999 simulate).
+ * Display surfaces (TrendingPairs, MarketsGrid TVL columns) overlay
+ * those values from `useAllPoolStats` when available.
+ *
+ * Each pool's `token0` / `token1` ordering matches the on-chain pool's
+ * canonical layout — for the curated set, frBTC was always slot 1
+ * (token1) at deployment. Verified via curl 2026-05-11.
  */
-export async function fetchCuratedPoolsListItems(
-  rpcUrl: string,
-): Promise<PoolsListItem[]> {
-  const detailsList = await Promise.all(
-    MAINNET_CURATED_POOLS.map((p) => fetchCuratedPoolDetails(rpcUrl, p.poolId)),
-  );
-
-  const items: PoolsListItem[] = [];
-  for (let i = 0; i < MAINNET_CURATED_POOLS.length; i++) {
-    const curated = MAINNET_CURATED_POOLS[i];
-    const details = detailsList[i];
-    if (!details) continue;
-
-    // Map token0 / token1 from on-chain so we don't drift if the pool
-    // was created with frBTC in the opposite slot.
-    const tokenSide =
-      details.token0Id === curated.tokenId ? 'token0' : 'token1';
-    const frBtcSide = tokenSide === 'token0' ? 'token1' : 'token0';
-
-    items.push({
-      id: details.poolId,
-      pairLabel: `${curated.symbol}/frBTC`,
-      token0: {
-        id: details.token0Id,
-        symbol: tokenSide === 'token0' ? curated.symbol : 'frBTC',
-        name: tokenSide === 'token0' ? curated.name : 'frBTC',
-      },
-      token1: {
-        id: details.token1Id,
-        symbol: frBtcSide === 'token0' ? curated.symbol : 'frBTC',
-        name: frBtcSide === 'token0' ? curated.name : 'frBTC',
-      },
-      token0Amount:
-        tokenSide === 'token0' ? details.reserve0 : details.reserve1,
-      token1Amount:
-        frBtcSide === 'token0' ? details.reserve0 : details.reserve1,
-      // Intentionally leave tvlUsd undefined — real TVL is overlaid from
-      // /api/pools/stats (poolStats in SwapShell.tsx) when available. The
-      // upstream low-TVL filter in usePools.ts is patched to keep entries
-      // with no explicit TVL data so the curated set survives.
-    } as PoolsListItem);
-  }
-
-  return items;
+export function getCuratedPoolsListItems(): PoolsListItem[] {
+  return MAINNET_CURATED_POOLS.map((p) => ({
+    id: p.poolId,
+    pairLabel: `${p.symbol} / frBTC LP`,
+    token0: {
+      id: p.tokenId,
+      symbol: p.symbol,
+      name: p.name,
+    },
+    token1: {
+      id: FRBTC_ID,
+      symbol: 'frBTC',
+      name: 'frBTC',
+    },
+  } as PoolsListItem));
 }
+
+/** Mainnet factory alkane id (the AMM router). */
+export const CURATED_FACTORY_ID = MAINNET_FACTORY_ID;
 
 /**
  * Set of curated token ids — used by the swap UI to decide whether a
@@ -187,3 +131,19 @@ export async function fetchCuratedPoolsListItems(
 export const CURATED_TOKEN_IDS: ReadonlySet<string> = new Set(
   MAINNET_CURATED_POOLS.map((p) => p.tokenId),
 );
+
+/** Set of curated pool ids. */
+export const CURATED_POOL_IDS: ReadonlySet<string> = new Set(
+  MAINNET_CURATED_POOLS.map((p) => p.poolId),
+);
+
+/**
+ * BACKWARD COMPAT: legacy export name preserved for callers that
+ * imported `fetchCuratedPoolsListItems`. Now synchronous-wrapped-in-Promise
+ * (no actual fetch). Migrate callers to `getCuratedPoolsListItems` over time.
+ */
+export async function fetchCuratedPoolsListItems(
+  _rpcUrl?: string,
+): Promise<PoolsListItem[]> {
+  return getCuratedPoolsListItems();
+}

--- a/lib/alkanes/rpc.ts
+++ b/lib/alkanes/rpc.ts
@@ -22,18 +22,37 @@
  * - `api.alkanode.com/rpc` `ammdata.get_pools` → works for mainnet pool data. ✅
  */
 
-import { SUBFROST_API_URLS, getRpcUrl } from '@/utils/getConfig';
+import { getRpcUrl } from '@/utils/getConfig';
 
 // ============================================================================
 // Shared fetch helpers
 // ============================================================================
 
 /**
- * Resolves the subfrost JSON-RPC endpoint for a given network name.
- * Accepts the same network strings as `getRpcUrl` / `SUBFROST_API_URLS`.
+ * The single browser-facing JSON-RPC endpoint for a network.
+ *
+ * Per flex 2026-05-11 ("we should never have more than 1 way to do
+ * something"), every browser-side RPC call funnels through the
+ * same-origin Next.js proxy at /api/rpc/${network} regardless of method.
+ * The proxy is the only place that knows about subfrost.io's broken
+ * /v4/<token> metashrew-unwrap path, the /v6/subfrost stickiness for
+ * metashrew_view, and the canon Espo (alkanode) REST routing — letting
+ * each helper pick its own upstream resurrects the routing-bug parade
+ * we just deleted.
+ *
+ * History: this used to point straight at SUBFROST_API_URLS[network],
+ * which on mainnet is /v4/<token>. /v4 was returning
+ * `error sending request for url (http://metashrew-unwrap:8080/)` for
+ * `metashrew_height`, which broke the swap quote engine end-to-end:
+ *   simulateContract → getHeight → POST /v4 → JSON-RPC error →
+ *   throw → fetchLivePoolState returns null → usePoolStateLive returns
+ *   null → useSwapQuotes can't compute a quote → user sees "no quote".
+ * Routing through /api/rpc fixes it because the proxy sends
+ * `metashrew_height` to the gateway URL on mainnet (which works) and
+ * `metashrew_view` to /v6 (which is the fast sticky path).
  */
 function subfrostRpcUrl(network: string): string {
-  return SUBFROST_API_URLS[network] || SUBFROST_API_URLS.mainnet;
+  return getRpcUrl(network);
 }
 
 /**
@@ -401,6 +420,9 @@ export async function metashrewView(
   blockTag: string = 'latest',
   signal?: AbortSignal,
 ): Promise<string> {
+  // Single upstream — the same-origin /api/rpc proxy. The proxy already
+  // routes metashrew_view to /v6/subfrost on mainnet (sticky, fast) and
+  // to the gateway on other networks. See subfrostRpcUrl above.
   return jsonRpcCall<string>(
     subfrostRpcUrl(network),
     'metashrew_view',

--- a/lib/amm/__tests__/volumeSeries.test.ts
+++ b/lib/amm/__tests__/volumeSeries.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { fillDailyForward } from '../volumeSeries';
+
+describe('fillDailyForward', () => {
+  it('returns [] for empty input', () => {
+    expect(fillDailyForward([], '2026-05-10')).toEqual([]);
+  });
+
+  it('returns single point unchanged when start === end', () => {
+    const out = fillDailyForward(
+      [{ time: '2026-05-10', value: 100 }],
+      '2026-05-10',
+    );
+    expect(out).toEqual([{ time: '2026-05-10', value: 100 }]);
+  });
+
+  it('extends a single past point forward to endDate with the same value', () => {
+    const out = fillDailyForward(
+      [{ time: '2026-05-08', value: 50 }],
+      '2026-05-10',
+    );
+    expect(out).toEqual([
+      { time: '2026-05-08', value: 50 },
+      { time: '2026-05-09', value: 50 },
+      { time: '2026-05-10', value: 50 },
+    ]);
+  });
+
+  it('fills the gap between two sparse points with carry-forward', () => {
+    const out = fillDailyForward(
+      [
+        { time: '2026-05-01', value: 100 },
+        { time: '2026-05-04', value: 250 },
+      ],
+      '2026-05-04',
+    );
+    expect(out).toEqual([
+      { time: '2026-05-01', value: 100 },
+      { time: '2026-05-02', value: 100 },
+      { time: '2026-05-03', value: 100 },
+      { time: '2026-05-04', value: 250 },
+    ]);
+  });
+
+  it('handles the user-reported "August 2025 to today" gap (cumulative monotonic)', () => {
+    const out = fillDailyForward(
+      [
+        { time: '2025-08-01', value: 100 },
+        { time: '2026-05-10', value: 250 },
+      ],
+      '2026-05-10',
+    );
+    // 2025-08-01 through 2026-05-10 inclusive = 283 days.
+    expect(out.length).toBe(283);
+    expect(out[0]).toEqual({ time: '2025-08-01', value: 100 });
+    expect(out[out.length - 1]).toEqual({ time: '2026-05-10', value: 250 });
+    // Every intermediate day should hold the prior value (100) until the
+    // jump on 2026-05-10.
+    expect(out.slice(1, -1).every((p) => p.value === 100)).toBe(true);
+  });
+
+  it('extends past lastPointDate when endDate is later', () => {
+    const out = fillDailyForward(
+      [
+        { time: '2026-05-01', value: 100 },
+        { time: '2026-05-03', value: 200 },
+      ],
+      '2026-05-05',
+    );
+    expect(out.length).toBe(5);
+    expect(out[3]).toEqual({ time: '2026-05-04', value: 200 });
+    expect(out[4]).toEqual({ time: '2026-05-05', value: 200 });
+  });
+
+  it('extends to lastPointDate (does not truncate) when endDate is earlier', () => {
+    const out = fillDailyForward(
+      [
+        { time: '2026-05-01', value: 100 },
+        { time: '2026-05-05', value: 300 },
+      ],
+      '2026-05-03', // earlier than lastPointDate
+    );
+    expect(out.length).toBe(5);
+    expect(out[out.length - 1]).toEqual({ time: '2026-05-05', value: 300 });
+  });
+
+  it('crosses a UTC year boundary correctly (no DST drift)', () => {
+    const out = fillDailyForward(
+      [
+        { time: '2025-12-30', value: 100 },
+        { time: '2026-01-02', value: 150 },
+      ],
+      '2026-01-02',
+    );
+    expect(out.map((p) => p.time)).toEqual([
+      '2025-12-30',
+      '2025-12-31',
+      '2026-01-01',
+      '2026-01-02',
+    ]);
+  });
+
+  it('crosses a leap day correctly', () => {
+    const out = fillDailyForward(
+      [
+        { time: '2024-02-28', value: 100 },
+        { time: '2024-03-01', value: 200 },
+      ],
+      '2024-03-01',
+    );
+    expect(out.map((p) => p.time)).toEqual([
+      '2024-02-28',
+      '2024-02-29',
+      '2024-03-01',
+    ]);
+  });
+});

--- a/lib/amm/volumeSeries.ts
+++ b/lib/amm/volumeSeries.ts
@@ -1,0 +1,78 @@
+/**
+ * Daily fill-forward for cumulative AMM volume series.
+ *
+ * The upstream `ammdata.get_total_volume_amm` endpoint emits one point per
+ * swap-event block (sparse). For a marketing-quality landing chart we want
+ * one tick per UTC day, with gaps filled by the most-recent cumulative value
+ * (cumulative volume is monotonic — "highest seen so far" == "value as of
+ * end of this day").
+ *
+ * Without this, a multi-month low-volume gap renders as a single straight
+ * segment between the two outer points, which is what the user reported on
+ * staging on 2026-05-10.
+ */
+
+export interface DatedValue {
+  /** ISO date string `YYYY-MM-DD` (UTC). */
+  time: string;
+  /** Cumulative USD value as of end of `time`. */
+  value: number;
+}
+
+/**
+ * Densify a sparse, sorted-ascending series of `(time, value)` points so
+ * that every UTC day from the first point's date through `endDate` (inclusive)
+ * has exactly one entry. Missing days inherit the most-recent prior value.
+ *
+ * Pure: no network, no clock. Caller supplies `endDate` (the renderer uses
+ * `today` derived from `Date.now()`).
+ *
+ * Inputs:
+ *   - `points` MUST be ASC-sorted by `time` and have unique `time` keys.
+ *     (The caller's bucketing step already guarantees this.)
+ *   - `endDate` ISO `YYYY-MM-DD` UTC; if earlier than the last point's date,
+ *     the function still returns through the last point's date (won't truncate).
+ *
+ * If `points` is empty, returns `[]`.
+ */
+export function fillDailyForward(
+  points: readonly DatedValue[],
+  endDate: string,
+): DatedValue[] {
+  if (points.length === 0) return [];
+
+  const startDate = points[0]!.time;
+  const lastPointDate = points[points.length - 1]!.time;
+
+  // The chart should always extend through "today" — but if `endDate` is
+  // earlier (e.g. clock skew), at least extend to the last data point.
+  const finalDate = endDate >= lastPointDate ? endDate : lastPointDate;
+
+  const valueByDate = new Map<string, number>();
+  for (const p of points) valueByDate.set(p.time, p.value);
+
+  const out: DatedValue[] = [];
+  let lastValue = points[0]!.value;
+  let cursor = startDate;
+  // Walk from the start date through finalDate inclusive, one UTC day at a
+  // time. Use Date arithmetic in UTC to avoid DST / local-tz drift.
+  while (cursor <= finalDate) {
+    const explicit = valueByDate.get(cursor);
+    if (explicit !== undefined) lastValue = explicit;
+    out.push({ time: cursor, value: lastValue });
+    cursor = nextUtcDay(cursor);
+  }
+  return out;
+}
+
+/** Add one UTC day to an ISO `YYYY-MM-DD` string. */
+function nextUtcDay(iso: string): string {
+  // ISO date strings parse as UTC midnight; +86_400_000 ms is exactly +1 day
+  // (UTC has no DST). Slice back to YYYY-MM-DD.
+  const ms = Date.UTC(
+    Number(iso.slice(0, 4)),
+    Number(iso.slice(5, 7)) - 1,
+    Number(iso.slice(8, 10)),
+  );
+  return new Date(ms + 86_400_000).toISOString().slice(0, 10);
+}

--- a/lib/fujin/rpc.ts
+++ b/lib/fujin/rpc.ts
@@ -15,10 +15,23 @@
  *                                    surface, which is a different host
  */
 
-import { metashrewView, getHeight } from '@/lib/alkanes/rpc';
+import { metashrewView } from '@/lib/alkanes/rpc';
 
-/** Encode unsigned integer as LEB128 */
+/**
+ * Encode unsigned integer as LEB128.
+ *
+ * Hardened 2026-05-11: a previous version would infinite-loop on non-finite or
+ * negative input — `Math.floor(NaN / 128)` is `NaN`, `NaN !== 0` is true, the
+ * loop never terminates, and `Array.push` eventually throws
+ * `RangeError: Invalid array length`. The trigger was an upstream failure (the
+ * metashrew_height probe returning undefined → `simulateContract` passing
+ * NaN as `height` → encodeLEB128 → infinite loop). Throw on bad input so the
+ * caller can fall back instead of crashing the whole React tree.
+ */
 function encodeLEB128(value: number): number[] {
+  if (!Number.isFinite(value) || value < 0 || !Number.isInteger(value)) {
+    throw new Error(`encodeLEB128: invalid input ${value} (must be non-negative finite integer)`);
+  }
   const bytes: number[] = [];
   let val = value;
   do {
@@ -113,17 +126,28 @@ export async function simulateContract(
 ): Promise<string> {
   const network = urlToNetwork(networkOrUrl);
   const [block, tx] = contractId.split(':').map(Number);
-  const height = await getHeight(network);
 
+  // No `getHeight` round-trip. The JSON-RPC `blockTag='latest'` (last arg
+  // to metashrewView below) tells the metashrew node to use the latest
+  // committed block — the protobuf `height` field is then ignored, so we
+  // can hardcode it to 0. Verified 2026-05-11 by curl: identical
+  // PoolDetails returned with height=0 vs height=948866.
+  //
+  // Why this matters: previously this called `getHeight(network)` which
+  // hit `metashrew_height` on /v4/subfrost. When subfrost.io was choking
+  // (Cloudflare 502/408 storms verified in dev log), getHeight threw,
+  // simulateContract threw, and the entire swap-quote pipeline collapsed
+  // into "no quote" — even though /v6/subfrost was happily serving
+  // metashrew_view simulate. One fewer upstream dependency = one fewer
+  // failure mode.
   const calldata: number[] = [];
   for (const val of [block, tx, opcode, ...args]) {
     calldata.push(...encodeLEB128(val));
   }
 
   const parts: number[] = [];
-  // Field 4: height (varint, tag 0x20)
-  parts.push(0x20);
-  parts.push(...encodeLEB128(height));
+  // Field 4: height (varint, tag 0x20) — encoded as 0; node uses 'latest'.
+  parts.push(0x20, 0x00);
   // Field 5: calldata (length-delimited, tag 0x2A)
   parts.push(0x2A);
   parts.push(...encodeLEB128(calldata.length));

--- a/lib/pools/__tests__/mergeStats.test.ts
+++ b/lib/pools/__tests__/mergeStats.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { pickPositive } from '../mergeStats';
+
+describe('pickPositive', () => {
+  it('returns 0 for no args', () => {
+    expect(pickPositive()).toBe(0);
+  });
+
+  it('returns 0 if every candidate is undefined / null', () => {
+    expect(pickPositive(undefined, null, undefined)).toBe(0);
+  });
+
+  it('returns 0 if every candidate is non-positive', () => {
+    expect(pickPositive(0, -1, 0, -100)).toBe(0);
+  });
+
+  it('returns the first finite > 0 candidate', () => {
+    expect(pickPositive(undefined, 0, 100, 200)).toBe(100);
+  });
+
+  it('skips NaN and Infinity', () => {
+    expect(pickPositive(NaN, Infinity, -Infinity, 50)).toBe(50);
+  });
+
+  it('does NOT short-circuit on zero (the bug this exists to prevent)', () => {
+    // Before: `pool.tvlUsd || stats?.tvlUsd || 0` returns 0 here.
+    // After: `pickPositive(pool.tvlUsd, stats?.tvlUsd)` returns 385234.
+    expect(pickPositive(0, 385234)).toBe(385234);
+  });
+
+  it('treats 0 as a valid "no data" sentinel and skips to next candidate', () => {
+    expect(pickPositive(undefined, 0, undefined, 42)).toBe(42);
+  });
+
+  it('strict positivity — does not return negative numbers', () => {
+    expect(pickPositive(-5, -10, 7)).toBe(7);
+  });
+});

--- a/lib/pools/mergeStats.ts
+++ b/lib/pools/mergeStats.ts
@@ -1,0 +1,26 @@
+/**
+ * Merge helpers for pool data overlays.
+ *
+ * Several home/swap surfaces derive a `PoolsListItem` by overlaying stats
+ * from `useAllPoolStats()` onto the base entries from `usePools()`. The
+ * common pattern was:
+ *
+ *   tvlUsd: pool.tvlUsd || stats?.tvlUsd || 0
+ *
+ * which silently short-circuits when `pool.tvlUsd === 0` — the OR returns
+ * the zero immediately and never consults `stats?.tvlUsd`. Symptom on
+ * staging 2026-05-10: DIESEL/frBTC TVL displayed as $0 in Markets despite
+ * the stats overlay holding the correct $385K value.
+ *
+ * `pickPositive` returns the first finite, strictly-positive candidate.
+ * Use this in place of `||` when you want a non-zero value to take priority
+ * over a zero-from-primary.
+ */
+
+export function pickPositive(...candidates: Array<number | undefined | null>): number {
+  for (const c of candidates) {
+    if (c == null) continue;
+    if (Number.isFinite(c) && c > 0) return c;
+  }
+  return 0;
+}

--- a/queries/__tests__/alkane-balance-aggregation.test.ts
+++ b/queries/__tests__/alkane-balance-aggregation.test.ts
@@ -170,8 +170,11 @@ describe('fetchAlkaneBalancesViaProtobuf source contract', () => {
     expect(balanceFn).not.toMatch(/protorunesbyaddress/);
   });
 
-  it('parallelizes per-outpoint queries via Promise.all', () => {
-    expect(src).toMatch(/Promise\.all\(checks\)/);
+  it('parallelizes per-outpoint queries via Promise.allSettled', () => {
+    // allSettled (not all) so a single failed outpoint doesn't poison the
+    // entire wallet display when the alkanode fallback would otherwise
+    // recover the data. See queries/account.ts step 4 fallback comment.
+    expect(src).toMatch(/Promise\.allSettled\(checks\)/);
   });
 
   it('filters to dust UTXOs (≤1000 sats) before fanning out', () => {

--- a/queries/__tests__/alkane-balance-rest-fallback.test.ts
+++ b/queries/__tests__/alkane-balance-rest-fallback.test.ts
@@ -1,0 +1,247 @@
+/**
+ * REST fallback path in `queries/account.ts::fetchAlkaneBalancesViaProtobuf`.
+ *
+ * Originally added in PR #112 to recover the balance display when subfrost's
+ * per-outpoint indexer drifts and returns `balance_sheet.cached.balances: []`
+ * for every dust UTXO at an address. Originally fetched
+ * `https://oyl.alkanode.com/get-alkanes-by-address` directly from the browser
+ * — a CLAUDE.md "no raw fetch in app code" violation that also relied on
+ * permissive third-party CORS AND silently failed to read
+ * `process.env.ESPO_MAINNET_FALLBACK_URL` (no `NEXT_PUBLIC_` prefix).
+ *
+ * Refactored 2026-05-11 (port of PR #115 idea, adapted to our canon):
+ *   - Routes through `/api/rpc/{network}/get-alkanes-by-address` so the
+ *     server-side proxy resolves the upstream. Per flex, REST sub-paths go
+ *     directly to canon Espo (alkanode) with NO subfrost.io fallback.
+ *   - The fallback fires when subfrost's per-outpoint fanout produces no
+ *     usable data — either uniformly empty results OR every outpoint failed
+ *     (Promise.allSettled). The OR-failed branch is unique to our canon and
+ *     covers the case where subfrost is timing out (5+ blocks behind tip).
+ *
+ * This suite mocks the rpc helpers + global fetch and asserts the fallback
+ * fires when (and only when) the documented signature matches.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the rpc.ts helpers BEFORE importing account.ts so the imported
+// `fetchAlkaneBalancesViaProtobuf` picks up the mocks.
+vi.mock('@/lib/alkanes/rpc', () => ({
+  getAddressUtxos: vi.fn(),
+  getProtorunesByOutpoint: vi.fn(),
+  getAddressMempoolTxs: vi.fn(),
+  getAlkaneInfoBatch: vi.fn(),
+}));
+
+import { fetchAlkaneBalancesViaProtobuf } from '../account';
+import * as rpc from '@/lib/alkanes/rpc';
+
+const ADDRESS = 'bc1p0eyy0testaddressformockingpurposesonly0000000';
+
+// Helpers --------------------------------------------------------------
+
+function makeDustUtxos(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    txid: 'a'.repeat(64).slice(0, 63) + i.toString(16),
+    vout: 0,
+    value: 546,
+  }));
+}
+
+function emptyBalanceSheet() {
+  return { balance_sheet: { cached: { balances: [] } } };
+}
+
+function balanceSheet(block: number, tx: number, amount: string | number) {
+  return { balance_sheet: { cached: { balances: [{ block, tx, amount }] } } };
+}
+
+function mockFallbackResponse(items: Array<{ block: string; tx: string; balance: string }>) {
+  return {
+    ok: true,
+    json: async () => ({
+      data: items.map((i) => ({
+        alkaneId: { block: i.block, tx: i.tx },
+        balance: i.balance,
+      })),
+    }),
+  } as unknown as Response;
+}
+
+// Test suite -----------------------------------------------------------
+
+describe('fetchAlkaneBalancesViaProtobuf — REST fallback', () => {
+  const fetchSpy = vi.fn();
+  const origFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchSpy.mockReset();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('fires fallback when subfrost returns empty for every dust UTXO on mainnet', async () => {
+    const dust = makeDustUtxos(3);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+
+    fetchSpy.mockResolvedValue(
+      mockFallbackResponse([{ block: '2', tx: '0', balance: '264482' }]),
+    );
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe('/api/rpc/mainnet/get-alkanes-by-address');
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address: ADDRESS }),
+    });
+    expect(result).toEqual([
+      { alkaneId: { block: '2', tx: '0' }, balance: '264482' },
+    ]);
+  });
+
+  it('fires fallback when EVERY per-outpoint call fails (subfrost timing out)', async () => {
+    // Unique to our canon: with Promise.allSettled, individual failures
+    // don't poison Promise.all. When all 3 outpoints fail, aggregate.size === 0
+    // AND failures === dustUtxos.length, so the fallback fires.
+    const dust = makeDustUtxos(3);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockRejectedValue(
+      new Error('subfrost timeout'),
+    );
+
+    fetchSpy.mockResolvedValue(
+      mockFallbackResponse([{ block: '2', tx: '0', balance: '264482' }]),
+    );
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { alkaneId: { block: '2', tx: '0' }, balance: '264482' },
+    ]);
+  });
+
+  it('does NOT fire fallback when subfrost returns at least one balance', async () => {
+    const dust = makeDustUtxos(3);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint)
+      .mockResolvedValueOnce(balanceSheet(2, 0, 100))
+      .mockResolvedValueOnce(emptyBalanceSheet())
+      .mockResolvedValueOnce(emptyBalanceSheet());
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      { alkaneId: { block: '2', tx: '0' }, balance: '100' },
+    ]);
+  });
+
+  it('partial failures do NOT poison results — successes are aggregated', async () => {
+    // 1 success + 2 failures: aggregate has the success, no fallback fires
+    // because aggregate.size > 0. (failures > 0 alone is not the trigger.)
+    const dust = makeDustUtxos(3);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint)
+      .mockResolvedValueOnce(balanceSheet(2, 0, 100))
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockRejectedValueOnce(new Error('timeout'));
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      { alkaneId: { block: '2', tx: '0' }, balance: '100' },
+    ]);
+  });
+
+  it('does NOT fire fallback on non-mainnet networks (alkanode hosts mainnet only)', async () => {
+    const dust = makeDustUtxos(3);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+
+    const result = await fetchAlkaneBalancesViaProtobuf('regtest', ADDRESS);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('does NOT fire fallback when address has no dust UTXOs', async () => {
+    // Wallet holds only BTC, no token-carrying dust outpoints. The
+    // empty-aggregate signature alone is not enough — we also require
+    // dustUtxos.length > 0, otherwise the user just doesn't hold alkanes.
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue([
+      { txid: 'a'.repeat(64), vout: 0, value: 100_000 }, // non-dust BTC
+    ]);
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    expect(rpc.getProtorunesByOutpoint).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty when fallback itself returns no data (subfrost + REST both empty)', async () => {
+    // Genuinely empty wallet that happens to have a few dust UTXOs (e.g. spent
+    // inscription dust). Fallback fires, returns empty, primary's empty
+    // aggregate is returned — no phantom data injected.
+    const dust = makeDustUtxos(2);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+
+    fetchSpy.mockResolvedValue(mockFallbackResponse([]));
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([]);
+  });
+
+  it('routes through proxy URL — never raw alkanode.com from the browser', async () => {
+    // Hard guarantee: no client-side raw fetch to oyl.alkanode.com.
+    // The proxy resolves the upstream server-side via REST_PRIMARY_BASE_URLS
+    // (alkanode primary on mainnet, per flex 2026-05-10).
+    const dust = makeDustUtxos(1);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+    fetchSpy.mockResolvedValue(mockFallbackResponse([]));
+
+    await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    for (const call of fetchSpy.mock.calls) {
+      const url = String(call[0]);
+      expect(url).not.toMatch(/alkanode\.com/);
+      expect(url).not.toMatch(/^https?:\/\//); // must be same-origin
+    }
+  });
+
+  it('survives fallback fetch throwing (network error) without crashing the caller', async () => {
+    const dust = makeDustUtxos(1);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+    fetchSpy.mockRejectedValue(new Error('connection refused'));
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+
+    // Fallback exception is caught; the primary's empty aggregate is returned.
+    expect(result).toEqual([]);
+  });
+
+  it('survives fallback returning non-2xx without crashing the caller', async () => {
+    const dust = makeDustUtxos(1);
+    vi.mocked(rpc.getAddressUtxos).mockResolvedValue(dust);
+    vi.mocked(rpc.getProtorunesByOutpoint).mockResolvedValue(emptyBalanceSheet());
+    fetchSpy.mockResolvedValue({ ok: false, status: 502, json: async () => ({}) } as unknown as Response);
+
+    const result = await fetchAlkaneBalancesViaProtobuf('mainnet', ADDRESS);
+    expect(result).toEqual([]);
+  });
+});

--- a/queries/account.ts
+++ b/queries/account.ts
@@ -287,8 +287,30 @@ export async function fetchAlkaneBalancesViaProtobuf(
     throw new Error(`getProtorunesByOutpoint(${txid}:${vout}) failed after retries: ${lastErr}`);
   };
 
+  // Use allSettled instead of all so a single subfrost failure doesn't
+  // poison the entire wallet display. A user with 100+ dust UTXOs against a
+  // degraded subfrost indexer would previously see zero balances because
+  // ONE timed-out outpoint rejected Promise.all before the alkanode fallback
+  // could fire (the `if (aggregate.size === 0)` branch was unreachable when
+  // any single fetch threw). With allSettled we still aggregate every
+  // success and fall back to alkanode if subfrost was uniformly empty OR
+  // uniformly failing — both signatures of an indexer-drift incident.
   const checks = dustUtxos.map((u) => fetchWithRetry(u.txid, u.vout));
-  const results = await Promise.all(checks);
+  const settled = await Promise.allSettled(checks);
+
+  let failures = 0;
+  const results: Array<Array<{ block: number | string; tx: number | string; amount: number | string }>> = [];
+  for (const r of settled) {
+    if (r.status === 'fulfilled') {
+      results.push(r.value);
+    } else {
+      failures += 1;
+      results.push([]);
+    }
+  }
+  if (failures > 0) {
+    console.warn(`[alkaneBalances] ${failures}/${dustUtxos.length} outpoints failed for ${address}`);
+  }
 
   // Step 3: aggregate per (block, tx).
   const aggregate = new Map<string, bigint>();
@@ -307,24 +329,28 @@ export async function fetchAlkaneBalancesViaProtobuf(
   }
 
   // Step 4: alkanode REST fallback when subfrost's alkane indexer drift
-  // causes every dust outpoint to come back with an empty balance sheet.
+  // causes every dust outpoint to come back empty (or fail).
   //
   // The 2026-05-10 mainnet incident: subfrost upstream returned valid HTTP 200
   // for every alkanes_protorunesbyoutpoint call but with `balances: []` in the
   // payload, while alkanode reported the wallet's actual DIESEL holdings via
-  // /get-alkanes-by-address. The per-outpoint fanout above can't tell the
-  // difference between "this outpoint is genuinely empty" and "subfrost is
-  // lying" — both shapes are structurally identical. So at the aggregate
-  // level we check: dust UTXOs exist (so SOMETHING should have value) but
-  // we got zero alkanes. That's the only signature of indexer drift.
+  // /get-alkanes-by-address. Subfrost's metashrew was 5+ blocks behind tip
+  // and intermittently 30s-timing-out per-outpoint queries; the per-outpoint
+  // fanout can't distinguish "outpoint genuinely empty" from "subfrost lying"
+  // from "subfrost timing out" — at the aggregate level all three look like
+  // {aggregate.size === 0}. So we trip the fallback when (a) we got nothing
+  // back AND dust UTXOs exist, or (b) every outpoint we asked about failed.
   //
   // SoT-1 still holds: subfrost is primary. Alkanode is consulted only when
-  // subfrost has zero data. If even one outpoint produces a balance, we
-  // trust subfrost completely and skip the fallback.
-  if (aggregate.size === 0 && dustUtxos.length > 0 && network === 'mainnet') {
-    const fallback = await tryAlkanodeAlkaneBalances(address);
+  // subfrost has produced zero usable data. If even one outpoint returned a
+  // non-zero balance we trust subfrost completely and skip the fallback.
+  const subfrostUseless =
+    (aggregate.size === 0 && dustUtxos.length > 0)
+    || (failures > 0 && failures === dustUtxos.length);
+  if (subfrostUseless && network === 'mainnet') {
+    const fallback = await tryRestAlkanesByAddress(network, address);
     if (fallback && fallback.length > 0) {
-      console.warn(`[alkaneBalances] subfrost returned 0 alkanes for ${dustUtxos.length} dust UTXOs at ${address}; using alkanode fallback (${fallback.length} entries)`);
+      console.warn(`[alkaneBalances] subfrost returned ${aggregate.size} alkanes (${failures}/${dustUtxos.length} failed) for ${address}; using REST fallback (${fallback.length} entries)`);
       return fallback;
     }
   }
@@ -335,21 +361,29 @@ export async function fetchAlkaneBalancesViaProtobuf(
   });
 }
 
-// Alkanode REST fallback for `fetchAlkaneBalancesViaProtobuf`. Used only
-// when subfrost upstream's alkane indexer returns 200-with-empty across every
-// dust outpoint at an address. Returns the same shape as the primary path so
-// callers can swap freely.
+// REST fallback for `fetchAlkaneBalancesViaProtobuf`. Used only when subfrost
+// upstream's alkane indexer returns 200-with-empty across every dust outpoint
+// at an address. Returns the same shape as the primary path so callers can
+// swap freely.
 //
-// Set `ESPO_MAINNET_FALLBACK_URL=""` (env) to disable. Defaults to alkanode.
-async function tryAlkanodeAlkaneBalances(
+// Routes through `/api/rpc/{network}/get-alkanes-by-address` so the proxy's
+// REST sub-path handler resolves the upstream (alkanode primary on mainnet,
+// per flex 2026-05-10). Previously this fetched `oyl.alkanode.com` directly
+// from the browser and read `process.env.ESPO_MAINNET_FALLBACK_URL` at
+// runtime — the env read silently returned `undefined` without a
+// `NEXT_PUBLIC_` prefix, so the override never worked client-side. Routing
+// through the proxy puts the URL config in one server-side place
+// (REST_PRIMARY_BASE_URLS in the mega-proxy) and lets ops swap it via a
+// single env var without rebuilding the client. (Pattern ported from PR #115
+// on subfrost/subfrost-app, but reframed: no `subfrost-fallback` semantic
+// here — the proxy already routes to alkanode primary, so this is just a
+// "use the same upstream as everything else" cleanup.)
+async function tryRestAlkanesByAddress(
+  network: string,
   address: string,
 ): Promise<{ alkaneId: { block: string; tx: string }; balance: string }[] | null> {
-  const fallbackBase = (typeof process !== 'undefined' && process.env?.ESPO_MAINNET_FALLBACK_URL !== undefined)
-    ? process.env.ESPO_MAINNET_FALLBACK_URL
-    : 'https://oyl.alkanode.com';
-  if (!fallbackBase) return null;
   try {
-    const resp = await fetch(`${fallbackBase.replace(/\/$/, '')}/get-alkanes-by-address`, {
+    const resp = await fetch(`/api/rpc/${network}/get-alkanes-by-address`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ address }),
@@ -368,7 +402,7 @@ async function tryAlkanodeAlkaneBalances(
       })
       .filter((x): x is { alkaneId: { block: string; tx: string }; balance: string } => x !== null);
   } catch (err) {
-    console.warn('[alkaneBalances] alkanode fallback threw:', err);
+    console.warn('[alkaneBalances] REST fallback threw:', err);
     return null;
   }
 }
@@ -505,12 +539,29 @@ export function walletUtxoCacheQueryOptions(deps: WalletUtxoCacheDeps) {
           }
           throw new Error(`getProtorunesByOutpoint(${txid}:${vout}) failed: ${lastErr}`);
         };
-        const sheets = await Promise.all(
+        // allSettled: a single failed dust outpoint must NOT poison the
+        // entire fanout. Subfrost.io's /v4/subfrost was returning Cloudflare
+        // 524s under burst load (verified 2026-05-11 dev log) — with
+        // Promise.all the first 524 rejected the whole cache build, the
+        // hook returned [], and alkanesExecuteTyped's prefetched_utxos
+        // skip-fanout shortcut never kicked in, kicking the SDK back to
+        // its own per-UTXO RPC fanout which then ALSO 524'd, hanging
+        // the swap-confirm modal for ~2 minutes. Treat any failed dust
+        // outpoint as "no asserted balance" (`alkanes: []`) — the SDK
+        // will fall back to RPC for that single outpoint at submit time
+        // if it's actually selected.
+        const sheetsSettled = await Promise.allSettled(
           dustUtxos.map((u) => fetchWithRetry(u.txid, u.vout)),
         );
+        let failedFanouts = 0;
         for (let i = 0; i < dustUtxos.length; i++) {
           const u = dustUtxos[i];
-          const balances = sheets[i] ?? [];
+          const settled = sheetsSettled[i];
+          if (!settled || settled.status === 'rejected') {
+            failedFanouts++;
+            continue;
+          }
+          const balances = settled.value ?? [];
           const alkanes: Array<{ block: number; tx: number; amount: bigint }> = [];
           for (const b of balances) {
             const amount = BigInt(String(b.amount ?? 0));
@@ -524,6 +575,11 @@ export function walletUtxoCacheQueryOptions(deps: WalletUtxoCacheDeps) {
           if (alkanes.length > 0) {
             alkaneMap.set(`${u.txid}:${u.vout}`, alkanes);
           }
+        }
+        if (failedFanouts > 0) {
+          console.warn(
+            `[walletUtxoCache] ${failedFanouts}/${dustUtxos.length} dust outpoint fanouts failed; cache built from successful ones`,
+          );
         }
       }
 
@@ -549,7 +605,7 @@ export function walletUtxoCacheQueryOptions(deps: WalletUtxoCacheDeps) {
       // consulted only when subfrost has zero data.
       if (alkaneMap.size === 0 && dustUtxos.length > 0 && deps.network === 'mainnet') {
         const fallbackByAddress = await Promise.all(
-          addresses.map((addr) => tryAlkanodeAlkaneBalances(addr).then((res) => ({ addr, res }))),
+          addresses.map((addr) => tryRestAlkanesByAddress(deps.network, addr).then((res) => ({ addr, res }))),
         );
         const totalFallbackEntries = fallbackByAddress.reduce(
           (sum, { res }) => sum + (res?.length ?? 0),
@@ -557,9 +613,9 @@ export function walletUtxoCacheQueryOptions(deps: WalletUtxoCacheDeps) {
         );
         if (totalFallbackEntries > 0) {
           console.warn(
-            `[walletUtxoCache] subfrost returned 0 alkanes for ${dustUtxos.length} dust UTXOs; using alkanode fallback (${totalFallbackEntries} entries across ${fallbackByAddress.length} addresses)`,
+            `[walletUtxoCache] subfrost returned 0 alkanes for ${dustUtxos.length} dust UTXOs; using REST fallback (${totalFallbackEntries} entries across ${fallbackByAddress.length} addresses)`,
           );
-          // Credit each address's alkanode balances to the first dust UTXO
+          // Credit each address's fallback balances to the first dust UTXO
           // belonging to that address. The SDK's selector treats the cache
           // as a hint about where balances live; the on-chain truth is
           // resolved at submit time, so any dust UTXO is a valid hint.
@@ -1218,10 +1274,19 @@ export function alkaneBalanceQueryOptions(deps: AlkaneBalanceDeps) {
       // "Token 2:NN" in the wallet, which is what gabe reports on
       // staging-app.subfrost.io.
       //
-      // Fix: one batched call to /api/token-details (via the SDK-mediated
-      // rpc.ts layer) for all unknown ids. Names are immutable, so the
-      // outer query's `staleTime: Infinity` (mainnet) caches the enriched
-      // result forever — HeightPoller is the only invalidator.
+      // Fix: one batched call to /api/token-details (which after PR-A is
+      // routed to canon Espo on alkanode — verified 2026-05-10 to return
+      // real name+symbol for any mainnet alkane). Names are immutable, so
+      // the outer query's `staleTime: Infinity` (mainnet) caches the
+      // enriched result forever — HeightPoller is the only invalidator.
+      //
+      // Display contract for AlkanesBalancesCard:
+      //   title       = entry.name      (e.g. "METHANE", "FARTANE")
+      //   description = entry.symbol + " · " + entry.alkaneId
+      //                 (e.g. "CH4 · 2:16", "H2S · 2:69")
+      // To honor that pattern, after enrichment we ensure BOTH name and
+      // symbol are populated for every alkane, falling back gracefully if
+      // alkanode returns only one.
       const unknownIds = [...alkaneMap.keys()].filter((id) => !KNOWN_TOKENS[id]);
       if (unknownIds.length > 0) {
         const meta = await getAlkaneInfoBatch(deps.network || 'mainnet', unknownIds);
@@ -1231,6 +1296,23 @@ export function alkaneBalanceQueryOptions(deps: AlkaneBalanceDeps) {
           if (info.name && entry.name === `Token ${id}`) entry.name = info.name;
           if (info.symbol && !entry.symbol) entry.symbol = info.symbol;
           if (info.decimals != null) entry.decimals = info.decimals;
+        }
+      }
+
+      // Final pass: any alkane that's still missing a `name` or `symbol`
+      // gets a sane derivation from whatever we DO have, so the wallet card
+      // never displays a generic placeholder. Order of preference:
+      //   - If `name` is still the "Token X:Y" placeholder but symbol is set,
+      //     use symbol as the name (some unknowns have only a symbol on chain).
+      //   - If `symbol` is still empty but name is real, mirror name into
+      //     symbol so the description line `${symbol} · ${id}` reads sensibly.
+      for (const [id, entry] of alkaneMap.entries()) {
+        const placeholderName = `Token ${id}`;
+        if (entry.name === placeholderName && entry.symbol) {
+          entry.name = entry.symbol;
+        }
+        if (!entry.symbol && entry.name && entry.name !== placeholderName) {
+          entry.symbol = entry.name;
         }
       }
 


### PR DESCRIPTION
## Summary

Five-part fix surfaced by today's mainnet swap-debug session.

1. **Route browser-side rpc helpers through the same-origin proxy.** `lib/alkanes/rpc.ts` was POSTing every helper directly at subfrost.io's `/v4/<token>`, which started returning `error sending request for url (http://metashrew-unwrap:8080/)` for `metashrew_height`. That broke the swap quote pipeline end-to-end (no quote shown). Switched `subfrostRpcUrl()` to `getRpcUrl(network)` so every browser-side RPC funnels through the existing same-origin Next.js proxy. Per flex 2026-05-11 ("we should never have more than 1 way to do something") this is the canonical single browser upstream.

2. **Drop `getHeight()` from `simulateContract`.** When `blockTag='latest'` is passed at the JSON-RPC layer the metashrew node ignores the protobuf height field — verified with curl that height=0 returns identical PoolDetails as height=948866. One fewer upstream round-trip per simulate AND one fewer failure mode (the height fetch was the most fragile call when subfrost is choking).

3. **Carry `poolId` in `calculateSwapPrice` early-returns.** When `liveState` is unavailable or the user hasn't typed an amount, `useSwapQuotes` returns a zero-quote object. Those early-return objects were missing `poolId`, which made `SwapShell`'s click guard at line 1503 spuriously fire `swapFailedPoolNotFound` whenever the user clicked Swap before the live state arrived.

4. **`allSettled` for dust outpoint fanout in `walletUtxoCache`.** Previously `Promise.all` — a single failed outpoint (subfrost.io 524 under burst load) rejected the entire fanout, the cache returned empty, the SDK's `prefetched_utxos` skip-fanout shortcut never engaged, and the WASM kicked back to its own per-UTXO RPC fanout which ALSO 524'd, hanging the swap-confirm modal for ~2 minutes. Treat any failed dust outpoint as "no asserted balance" so the cache builds from successful ones.

5. **Add `ESPO_MAINNET_PRIMARY_URL` routing for REST sub-paths** (per flex 2026-05-10 — REST sub-paths bypass subfrost.io and go directly to canon Espo on alkanode for mainnet, no fallback). Plus `lib/pools/mergeStats.ts::pickPositive` so TrendingPairs/SwapShell don't let a `0` from the primary stats source short-circuit the overlay merge, and `lib/amm/volumeSeries.ts` to densify the cumulative AMM volume chart with daily fill-forward (smooths the staircase the user saw on the home page).

## Test plan

End-to-end DIESEL/frBTC swap through the local dev server (port 3000) on 2026-05-11:
- [x] `direct pool found: id=2:77087 token0=2:0 token1=32:0`
- [x] `prefetched_utxos: 24 TxOuts (2 with alkane assertion)` — skips ~48 `getrawtransaction` + 24 `protorunesbyoutpoint` roundtrips
- [x] `payment_utxos: 9 clean BTC UTXOs from prefetched cache`
- [x] Protostone built: `[4,65522,13,2,2,0,32,0,3000000,1182,948875]` (factory opcode 13, exact-in 3M DIESEL → frBTC)
- [x] Quote populates within ~1s
- [ ] Modal pop is now blocked only by the SDK's `WAIT_FOR_INDEXER_SYNC` gate when subfrost's metashrew indexer is multiple blocks behind bitcoind (observed 6-block lag during testing — outside the developer's control; submission goes through immediately once subfrost recovers)
- [x] Lint clean (0 errors, 104 pre-existing warnings unchanged)

Adds `CLAUDE.md` warning documenting the proxy routing matrix and the SDK sync poll trap so `metashrew_height` never gets accidentally moved onto /v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)