### PR TITLE
fix(rpc): route metashrew_height to /v6 to avoid stale-replica drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,17 +274,27 @@ Available helpers (canonical surface):
 
 When you next edit any of those files, swap the raw fetch for the corresponding `rpc.*` helper.
 
-### ⚠️ Mainnet metashrew routing — DO NOT MOVE `metashrew_height` ONTO /v6
+### Mainnet metashrew routing — both view AND height go to /v6
 
-`app/api/rpc/[[...segments]]/route.ts` splits mainnet metashrew JSON-RPC traffic by method:
+`app/api/rpc/[[...segments]]/route.ts` routes mainnet metashrew JSON-RPC traffic this way:
 
 | Method | Endpoint | Why |
 |--------|----------|-----|
 | `metashrew_view` | `/v6/subfrost` (sticky, fast) | 12–30× faster on the wallet UTXO prewarm fanout (parallel `alkanes_protorunesbyoutpoint`). |
-| `metashrew_height` | `/v4/subfrost` (gateway) | /v6 rate-limits aggressive bursts. The SDK's `WebProvider::sync` polls `metashrew_height` every ~500ms for up to 30s while waiting for the indexer to catch up to bitcoind, and reliably trips /v6's burst limit (429 after ~7-8 calls in ~3.5s). The 429 propagates as "Network error: HTTP error: 429" and the swap aborts. /v4 doesn't rate-limit and the single-call latency penalty is negligible. |
+| `metashrew_height` | `/v6/subfrost` (sticky) | **Must co-locate with `metashrew_view`** so both calls see the same replica's indexer state. See note below. |
 | Everything else (`alkanes_*`, `bitcoin_*`, `esplora_*`) | `/v4/subfrost` | /v6 only serves metashrew JSON-RPC. |
 
-DO NOT consolidate `metashrew_height` back onto /v6 for "consistency" — the perf benefit is zero (single trivial call, no fanout) and the cost is total swap failure during normal 1-block indexer-lag windows (which happen every ~10 minutes on mainnet). Verified 2026-05-10 (commit `3d3b48eb`).
+**Why height moved from /v4 to /v6 (2026-05-11)**: /v4 and /v6 route to DIFFERENT subfrost replicas with independent indexer state. Verified live 2026-05-11:
+```
+/v4 metashrew_height -> 948881
+/v6 metashrew_height -> 948886  (5 blocks ahead of /v4)
+bitcoind getblockcount -> 948888
+```
+The /v4 replica was lagging /v6 by 5 blocks. The SDK's sync gate computed `lag = bitcoind - metashrew_height = 7`, burned all 60 retries (~30s) and aborted with "Indexer sync timed out" — even though the *real* lag against the fresher replica (/v6) was only 2 blocks and would have closed in seconds. Routing height to /v6 closes that cross-replica drift.
+
+**Why we used to keep height on /v4** (now stale): commit `3d3b48eb` added the split because /v6 was returning HTTP 429 under the SDK's ~500ms poll cadence. Re-verified 2026-05-11 by hammering /v6 8 times at 500ms intervals: 8/8 succeeded with HTTP 200 in ~70ms each, no 429. Whatever rate-limit window /v6 used to enforce has been raised or removed.
+
+**If /v6 starts 429-ing height again**: the symptom is "Network error: HTTP error: 429" inside `Waiting for indexer to sync`. Options: (a) split height back to /v4 with an exponential backoff in the proxy, (b) move only the height polling onto a dedicated low-cap endpoint, OR (c) request flex/subfrost raise the limit. Re-verify the rate-limit threshold before changing the routing back.
 
 **Note on REST sub-paths**: those (`/get-pool-details`, `/get-alkanes`, `/get-alkane-details`, etc.) are NOT routed through subfrost.io at all. Per flex (alkanes-rs maintainer, 2026-05-10): "All of the /v4/subfrost/* routes other than BTC pricing are espo routes. They should be bypassed and go directly to espo." REST sub-paths route to canon Espo on alkanode (`oyl.alkanode.com`) with no subfrost.io fallback. See `REST_PRIMARY_BASE_URLS` in the proxy and the route-specific files (`app/api/pools/cached`, `app/api/pools/stats`, `app/api/token-names`, `app/api/token-details`).
 

--- a/app/api/rpc/[[...segments]]/route.ts
+++ b/app/api/rpc/[[...segments]]/route.ts
@@ -52,22 +52,24 @@ const RPC_ENDPOINTS: Record<string, string> = {
 };
 
 // Per-network metashrew-only endpoint. When set for a network, JSON-RPC
-// requests with method `metashrew_view` route here instead of
-// `RPC_ENDPOINTS[network]` — that's the per-outpoint fanout used by the
-// wallet cache prewarm. Other methods (including `metashrew_height`,
-// `bitcoin_*`, `alkanes_*`, `esplora_*`) and REST sub-paths still go
-// through the gateway endpoint.
+// requests with `metashrew_view` AND `metashrew_height` route here instead
+// of `RPC_ENDPOINTS[network]`. Other methods (`bitcoin_*`, `alkanes_*`,
+// `esplora_*`) and REST sub-paths still go through the gateway endpoint.
 //
-// `metashrew_height` deliberately stays on the gateway (NOT here) because
-// the SDK's `WebProvider::sync` polls it every ~500ms while waiting for
-// the indexer to catch up — that polling rate trips /v6/subfrost's burst
-// rate limit and the swap aborts with HTTP 429. The gateway is slower per
-// call but doesn't rate-limit, which matters more for a poll loop than
-// for a single height check.
+// Both metashrew methods share the /v6 route because /v4 and /v6 route to
+// DIFFERENT subfrost replicas with independent indexer state — and /v4 has
+// been observed lagging /v6 by 5+ blocks under load. Routing height to /v4
+// while view stayed on /v6 made the SDK's sync gate see a phantom multi-
+// block lag and time out (948881 from /v4 vs 948886 from /v6 vs 948888
+// from bitcoind, observed 2026-05-11). Co-locating height and view on the
+// same replica eliminates the cross-replica drift.
 //
-// Mainnet uses /v6/subfrost which is metashrew-sticky and significantly faster
-// for the wallet cache prewarm fanout. Other networks left undefined (no
-// override → use the gateway URL for everything).
+// See `pickEndpoint` below for the full rationale (including why the
+// previously-feared /v6 rate-limit on the SDK's 500ms height poll was
+// re-verified to no longer fire).
+//
+// Other networks left undefined (no override → use the gateway URL for
+// everything).
 const METASHREW_RPC_ENDPOINTS: Record<string, string | undefined> = {
   mainnet: 'https://mainnet.subfrost.io/v6/subfrost',
 };
@@ -123,23 +125,39 @@ function pickEndpoint(body: any, network: string) {
     return BATCH_RPC_ENDPOINTS[network] || BATCH_RPC_ENDPOINTS.regtest;
   }
 
-  // Single requests: route metashrew_view to the dedicated metashrew endpoint
-  // when the network has one configured (the perf-critical fanout path).
-  // Everything else — including metashrew_height — routes to the gateway.
+  // Single requests: route both metashrew_view AND metashrew_height to the
+  // dedicated metashrew endpoint when the network has one configured.
   //
-  // metashrew_height EXCLUSION rationale (2026-05-10): the SDK's
-  // `WebProvider::sync` polls metashrew_height every ~500ms while waiting
-  // for the indexer to catch up to bitcoind (up to 60 attempts = 30s).
-  // /v6/subfrost rate-limits aggressive bursts (HTTP 429), and the SDK's
-  // poll loop trips that limit reliably during 1-block lag windows. The
-  // 429 propagates as "Network error: HTTP error: 429" and the swap
-  // aborts. The gateway URL doesn't rate-limit; metashrew_height is a
-  // cheap call there. So we keep the perf benefit on the heavy
-  // metashrew_view path while keeping sync polling reliable.
+  // Why metashrew_height now goes to /v6 (UPDATED 2026-05-11):
+  // /v4/subfrost and /v6/subfrost route to DIFFERENT replicas with
+  // independent indexer state. Verified live 2026-05-11:
+  //   /v4 metashrew_height -> 948881
+  //   /v6 metashrew_height -> 948886  (5 blocks ahead of /v4)
+  //   bitcoind getblockcount -> 948888
+  // The /v4 replica was lagging the /v6 replica by 5 blocks, which made
+  // the SDK's sync gate see a 7-block lag (948888 - 948881) when the
+  // *real* lag against the fresher replica was only 2 blocks (948888 -
+  // 948886). The 2-block apparent lag would close in seconds; the
+  // 7-block apparent lag burned all 60 sync retries (~30s) and the swap
+  // aborted with "Indexer sync timed out".
+  //
+  // The earlier "DO NOT route metashrew_height to /v6" warning (commit
+  // 3d3b48eb) was based on /v6 returning HTTP 429 under the SDK's
+  // ~500ms poll cadence. Re-verified 2026-05-11 by hammering /v6 8 times
+  // at 500ms intervals: 8/8 succeeded with HTTP 200 in ~70ms each, no
+  // 429. Whatever rate-limit window /v6 used to enforce is gone (or
+  // raised), so the safety reason for keeping height on /v4 no longer
+  // applies — and /v4's stale-replica drift is now the bigger risk.
+  //
+  // If /v6 starts 429-ing the height poll again, the symptom is "Network
+  // error: HTTP error: 429" inside `Waiting for indexer to sync` — at
+  // that point split metashrew_height back to /v4 with an exponential
+  // backoff in the proxy, OR move only the height polling onto a
+  // dedicated low-cap endpoint.
   const method = typeof body?.method === 'string' ? body.method : '';
-  const isStickyMetashrew = method === 'metashrew_view';
+  const isMetashrew = method === 'metashrew_view' || method === 'metashrew_height';
   const metashrewUrl = METASHREW_RPC_ENDPOINTS[network];
-  if (isStickyMetashrew && metashrewUrl) {
+  if (isMetashrew && metashrewUrl) {
     return metashrewUrl;
   }
 


### PR DESCRIPTION
## Summary

`/v4/subfrost` and `/v6/subfrost` route to **different subfrost replicas** with independent indexer state. Verified live 2026-05-11:

```
/v4 metashrew_height -> 948881
/v6 metashrew_height -> 948886  (5 blocks ahead of /v4)
bitcoind getblockcount -> 948888
```

Routing `metashrew_height` to /v4 while `metashrew_view` stays on /v6 made the SDK's `WebProvider::sync` gate compute `lag = bitcoind - metashrew_height = 7` (against the stale /v4 replica), burn all 60 retries (~30s) and abort with `Indexer sync timed out`. The *real* lag against the fresher replica was only 2 blocks and would have closed in seconds.

User-reported swap modal hang on staging 2026-05-11 — confirmed in dev log:

```
Waiting for indexer to sync: metashrew at 948881, bitcoind at 948888 (60/60)
WASM.alkanesExecuteTyped[network=mainnet] FAILED
error: Execution failed: Other error: Indexer sync timed out: ...
```

Co-locating both metashrew calls on /v6 eliminates the cross-replica drift.

## Why this contradicts the previous PR

The earlier "DO NOT route `metashrew_height` to /v6" warning (commit `3d3b48eb`, PR #114) was based on /v6 returning HTTP 429 under the SDK's ~500ms poll cadence. **Re-verified 2026-05-11** by hammering /v6 8 times at 500ms intervals: 8/8 succeeded with HTTP 200 in ~70ms each, no 429. Whatever rate-limit window /v6 used to enforce has been raised or removed.

## Test plan

- [x] Verified /v4 vs /v6 height drift live (5-block difference at time of PR)
- [x] Verified /v6 no longer 429s the SDK's 500ms poll cadence (8/8 successes)
- [ ] User clicks Swap on staging — modal pops within `lag * ~1s` instead of timing out at 30s
- [ ] Watch dev log for `[INFO] Waiting for indexer to sync: metashrew at X, bitcoind at Y` — should now consistently show ≤2-block lag instead of 5-7

## Reversion criteria

If /v6 starts 429-ing the height poll, the symptom is `Network error: HTTP error: 429` inside `Waiting for indexer to sync`. CLAUDE.md updated with the decision tree:
1. Split height back to /v4 with exponential backoff in proxy
2. Move only the height polling onto a dedicated low-cap endpoint
3. Request flex/subfrost raise the limit

Re-verify the rate-limit threshold before reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)